### PR TITLE
[A2Y-15] 개발환경 CI CD 구축

### DIFF
--- a/.github/workflows/cicd-dev.yaml
+++ b/.github/workflows/cicd-dev.yaml
@@ -1,0 +1,75 @@
+name: cicd-dev
+
+on:
+    push:
+        branches: develop
+
+env:
+    ACTIVE_PROFILE: "dev"
+    DOCKERHUB_ID: ${{ secrets.DOCKERHUB_ID }}
+    DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+    DOCERHUB_REPO: ${{ secrets.DOCERHUB_REPO }}
+
+jobs:
+    build-and-ci:
+        runs-on: ubuntu-latest
+        outputs:
+            image_tag: ${{ steps.image_tag.outputs.image_tag }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
+              with:
+                  java-version: '17'
+                  distribution: 'temurin'
+
+            - name: Cache Gradle packages
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                  restore-keys: |
+                      ${{ runner.os }}-gradle-
+
+            - name: Create yaml file
+              run: |
+                  touch ./src/main/resources/application-$ACTIVE_PROFILE.yml
+                  echo "${{ secrets.APPLCATION_YAML }}" >> ./src/main/resources/application-$ACTIVE_PROFILE.yml
+
+            - name: Add permission for gradlew
+              run: chmod +x ./gradlew
+
+            - name: gradle Build
+              run: ./gradlew build
+
+            - name: Make image tag value
+              run: echo "IMAGE_TAG=$ACTIVE_PROFILE-${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+            - name: Build docker image and push image
+              run: |
+                  docker login -u $DOCKERHUB_ID -p $DOCKERHUB_PASSWORD
+                  docker build --build-arg SPRING_PROFILES_ACTIVE=$ACTIVE_PROFILE -t $DOCERHUB_REPO:${{env.IMAGE_TAG}} .
+                  docker push $DOCERHUB_REPO:${{env.IMAGE_TAG}}
+
+            - name: Pass Image tag value
+              id: image_tag
+              run: echo "image_tag=${{env.IMAGE_TAG}}" >> $GITHUB_OUTPUT
+
+    cd:
+        needs: build-and-ci
+        runs-on: [ yapp-server ]
+        steps:
+            - name: Set image tag value from output value
+              run: echo "IMAGE_TAG=${{ needs.build-and-ci.outputs.image_tag }}" >> $GITHUB_ENV
+
+            - name: Run docker image
+              run: |
+                  docker pull $DOCERHUB_REPO:${{env.IMAGE_TAG}}
+                  docker stop yapp 2> /dev/null || echo "yapp container doesn't exist"
+                  docker rm yapp 2> /dev/null || echo "yapp container doesn't exist"
+                  docker run --restart always -d -p 80:8080 --name yapp $DOCERHUB_REPO:${{env.IMAGE_TAG}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:17-jdk-slim-buster
+
+ARG SPRING_PROFILES_ACTIVE
+ENV SPRING_PROFILES_ACTIVE $SPRING_PROFILES_ACTIVE
+ENV TZ "Asia/Seoul"
+ENV JAR_FILE build/libs/item-finder-0.0.1-SNAPSHOT.jar
+ENV JAVA_OPTS="-Dspring.profiles.active=$SPRING_PROFILES_ACTIVE"
+
+WORKDIR /app
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+COPY ${JAR_FILE} app.jar
+
+ENTRYPOINT java $JAVA_OPTS -jar app.jar


### PR DESCRIPTION
### 변경 내용 요약
개발환경 CI CD 구축

### 작업한 내용
- 도커 이미지 설정
- cicd-dev github action 정의

**개발환경 cicd는 아래와 같은 스텝으로 진행됩니다**
- build-and-ci
  - 환경 설정 담은 값(application-dev.yml) 복사 & 서버 빌드 진행
  - 이미지 태그 생성 (워크 플로우를 트리거하는 SHA 값에서 7자리 값을 뽑아서 dev prefix 뒤에 붙입니다) ex. dev-12e93de
  - 이미지 빌드 후 도커 허브에 푸시

- cd
  - 위에서 사용한 이미지 태그를 통해 EC2 인스턴스에서 해당 이미지 pull 받음
  - 기존에 존재하는 컨테이너 있으면 종료 및 제거 (컨테이너 명: yapp)
  - 이번에 새로 빌드한 이미지 실행

## 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-15)

### 기타 사항
- [서버 노션 문서](https://www.notion.so/Server-7a52794d3aa34e36ad8e72ae850fa3b3#20f0f08c35564521870f82ffd149cb6c)에 작업하면서 참고한 링크와 관련 부가 설명을 작성했어요. 참고해시면 좋을 것 같아요!
- 테스트를 위해 이 브랜치에서 cicd 액션을 돌려봤습니다. 해당 액션은 [이곳](https://github.com/YAPP-Github/21st-Android-Team-2-BE/actions/runs/3501611178)에서 볼 수 있어요
