### PR TITLE
[A2Y-23] Swagger 연동

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val querydslVersion: String by project
+val springdocVersion: String by project
 val kotestVersion: String by project
 val mockkVersion: String by project
 
@@ -35,6 +36,11 @@ dependencies {
 	//querydsl
 	implementation("com.querydsl:querydsl-jpa:${querydslVersion}")
 	kapt("com.querydsl:querydsl-apt:${querydslVersion}:jpa")
+	// swagger
+	implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")
+	// security
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	testImplementation("org.springframework.security:spring-security-test")
 
 	//h2
 	testImplementation("com.h2database:h2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 querydslVersion = 5.0.0
+springdocVersion = 1.6.13
 kotestVersion = 4.4.3
 mockkVersion = 1.12.0

--- a/src/main/kotlin/com/yapp/itemfinder/config/SecurityFilterConfig.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/SecurityFilterConfig.kt
@@ -1,0 +1,63 @@
+package com.yapp.itemfinder.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityFilterConfig {
+    companion object {
+        private const val ADMIN_ROLE_NAME = "ADMIN"
+    }
+
+    @Value("\${admin.username:#{'default'}}")
+    lateinit var adminUserName: String
+
+    @Value("\${admin.password:#{'default'}}")
+    lateinit var adminPassword: String
+
+    // swagger 결과는 어드민 아이디/비번으로 로그인해야 접근 가능, 나머지 Endpoint는 모두 접근 가능
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeRequests()
+            .antMatchers( "/api-docs/**").hasAuthority(ADMIN_ROLE_NAME)
+            .and()
+            .httpBasic()
+            .and()
+            .csrf()
+            .disable()
+
+        return http.build()
+    }
+
+    @Profile("!prod")
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Profile("!prod")
+    @Bean
+    fun userDetailsService(passwordEncoder: PasswordEncoder): UserDetailsService {
+        val user: UserDetails =  User.withUsername(adminUserName)
+            .password(passwordEncoder.encode(adminPassword))
+            .authorities(SimpleGrantedAuthority(ADMIN_ROLE_NAME))
+            .build()
+        return InMemoryUserDetailsManager(user)
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/config/SpringDocConfig.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/SpringDocConfig.kt
@@ -1,0 +1,49 @@
+package com.yapp.itemfinder.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.ExternalDocumentation
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SpringDocConfig {
+    companion object {
+        private const val JWT_SCHEME_NAME = "JWT"
+        private const val JWT_PREFIX = "bearer"
+    }
+
+    @Bean
+    fun openApi(): OpenAPI {
+        return OpenAPI()
+            .info(
+                Info().title("Item finder API Docs")
+                    .description("Item finder Application")
+                    .version("v0.0.1")
+                    .license(License().name("Server Github link").url("https://github.com/YAPP-Github/21st-Android-Team-2-BE"))
+            )
+            .externalDocs(
+                ExternalDocumentation()
+                    .description("Android Github link")
+                    .url("https://github.com/YAPP-Github/21st-Android-Team-2-Android")
+            )
+            .components(
+                Components()
+                    .addSecuritySchemes(JWT_SCHEME_NAME, createSecurityScheme())
+            )
+            .addSecurityItem(
+                SecurityRequirement().addList(JWT_SCHEME_NAME)
+            )
+    }
+
+    private fun createSecurityScheme(): SecurityScheme {
+        return SecurityScheme()
+            .name(JWT_SCHEME_NAME)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme(JWT_PREFIX)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,6 @@ spring:
   config:
     activate.on-profile: local
 
-  datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/test
-    username: test
-    password: "0000"
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,44 @@
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+    database-platform: org.hibernate.dialect.MariaDBDialect
 
+springdoc:
+  api-docs:
+    path: "/api-docs"
+
+---
+spring:
+  config:
+    activate.on-profile: local
+
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/test
+    username: test
+    password: "0000"
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+admin:
+  username: "1"
+  password: "test"
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+---
+spring:
+  config:
+    activate.on-profile: prod
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
@@ -27,6 +27,7 @@ abstract class ControllerIntegrationTest {
     ) {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
             .addFilter<DefaultMockMvcBuilder>(CharacterEncodingFilter("UTF-8", true))
+            .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
             .alwaysDo<DefaultMockMvcBuilder>(MockMvcResultHandlers.print())
             .build()
     }

--- a/src/test/kotlin/com/yapp/itemfinder/config/SecurityFilterConfigTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/config/SecurityFilterConfigTest.kt
@@ -1,0 +1,32 @@
+package com.yapp.itemfinder.config
+
+import com.yapp.itemfinder.ControllerIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.get
+
+class SecurityFilterConfigTest : ControllerIntegrationTest() {
+    @Value("\${springdoc.api-docs.path}")
+    lateinit var apiDocPath: String
+
+    @WithMockUser(value = "loginUser", authorities = ["USER"])
+    @Test
+    fun `일반 유저는 스웨거 페이지에 접속할 수 없다`() {
+        // expect & then
+        mockMvc.get(apiDocPath) {
+        }.andExpect {
+            status { is4xxClientError() }
+        }.andReturn()
+    }
+
+    @WithMockUser(value = "admin", authorities = ["ADMIN"])
+    @Test
+    fun `어드민 권한을 가진 유저는 스웨거 페이지에 접속할 수 있다`() {
+        // expect & then
+        mockMvc.get(apiDocPath) {
+        }.andExpect {
+            status { is2xxSuccessful() }
+        }.andReturn()
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,3 +11,12 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+admin:
+  username: "test"
+  password: "test"
+
+
+springdoc:
+  api-docs:
+    path: "/api-docs"


### PR DESCRIPTION
### 변경 내용 요약
Swagger 연동

### 작업한 내용
- 서버(개발, 로컬 환경)에서 어드민 아이디/비번을 입력해야 스웨거 페이지에 접속할 수 있습니다.  
- 운영 환경 서버(현재 미구축)에선 스웨거 엔드포인트를 비활성화합니다 (스웨거 제공 X)
- 추후 JWT 로그인을 진행할 예정이므로, 스웨거에서 헤더에 토큰 값 넣을 수 있도록 설정을 추가했습니다.

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-23)

### 기타 사항

헤더에 토큰 값 설정하는 방식은 아래와 같습니다!
1. 토큰 값 설정
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/63828890/204560711-24ec3e65-febe-47f6-8783-07e515ce4447.png">
2. 요청에서 헤더에 토큰 설정한 값이 세팅된 것을 확인할 수 있습니다.
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/63828890/204561369-71663361-6893-4578-b6f3-706e9b50aacf.png">

- Ref
  - [Spring doc 문서 링크](https://springdoc.org/)