### PR TITLE
[A2Y-140] 홈화면 관련 API 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -4,7 +4,9 @@ import com.yapp.itemfinder.domain.BaseEntity
 import com.yapp.itemfinder.domain.item.ItemType
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import org.hibernate.annotations.ColumnDefault
+import javax.persistence.AttributeConverter
 import javax.persistence.Column
+import javax.persistence.Convert
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -25,8 +27,9 @@ class ContainerEntity(
     space: SpaceEntity,
     name: String,
     defaultItemType: ItemType = ItemType.LIFESTYLE,
-    description: String?,
-    imageUrl: String?,
+    iconType: IconType = IconType.IC_CONTAINER_1,
+    description: String? = null,
+    imageUrl: String? = null,
     id: Long = 0L
 ) : BaseEntity(id) {
 
@@ -45,9 +48,35 @@ class ContainerEntity(
     var defaultItemType: ItemType = defaultItemType
         protected set
 
+    @Convert(converter = IconTypeConverter::class)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    var iconType: IconType = iconType
+        protected set
+
     var description: String? = description
         protected set
 
     var imageUrl: String? = imageUrl
         protected set
+}
+
+enum class IconType(val value: Int) {
+    IC_CONTAINER_1(1),
+    IC_CONTAINER_2(2),
+    IC_CONTAINER_3(3),
+    IC_CONTAINER_4(4),
+    IC_CONTAINER_5(5),
+    IC_CONTAINER_6(6),
+    IC_CONTAINER_7(7),
+    IC_CONTAINER_8(8)
+}
+
+class IconTypeConverter : AttributeConverter<IconType, Int> {
+    override fun convertToDatabaseColumn(attribute: IconType?): Int {
+        return attribute?.value ?: IconType.IC_CONTAINER_1.value
+    }
+
+    override fun convertToEntityAttribute(dbData: Int): IconType {
+        return IconType.values().firstOrNull { it.value == dbData } ?: IconType.IC_CONTAINER_1
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -4,11 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
-    @Query("select new com.yapp.itemfinder.domain.container.SpaceIdWithContainerIcon(c.space.id as spaceId, c.iconType) from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
-    fun findIconTypeBySpaceIdIsIn(spaceIds: List<Long>): List<SpaceIdWithContainerIcon>
+    @Query("select c from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
+    fun findBySpaceIdIsIn(spaceIds: List<Long>): List<ContainerEntity>
 }
-
-data class SpaceIdWithContainerIcon(
-    val spaceId: Long,
-    val iconType: IconType
-)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -4,11 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
-    @Query("select new com.yapp.itemfinder.domain.container.SpaceIdToContainerIcon(c.space.id as spaceId, c.iconType) from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
-    fun findIconTypeBySpaceIdIsIn(spaceIds: List<Long>): List<SpaceIdToContainerIcon>
+    @Query("select new com.yapp.itemfinder.domain.container.SpaceIdWithContainerIcon(c.space.id as spaceId, c.iconType) from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
+    fun findIconTypeBySpaceIdIsIn(spaceIds: List<Long>): List<SpaceIdWithContainerIcon>
 }
 
-data class SpaceIdToContainerIcon(
+data class SpaceIdWithContainerIcon(
     val spaceId: Long,
     val iconType: IconType
 )

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -1,0 +1,14 @@
+package com.yapp.itemfinder.domain.container
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
+    @Query("select new com.yapp.itemfinder.domain.container.SpaceIdToContainerIcon(c.space.id as spaceId, c.iconType) from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
+    fun findIconTypeBySpaceIdIsIn(spaceIds: List<Long>): List<SpaceIdToContainerIcon>
+}
+
+data class SpaceIdToContainerIcon(
+    val spaceId: Long,
+    val iconType: IconType
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/ContainerResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/ContainerResponse.kt
@@ -1,0 +1,22 @@
+package com.yapp.itemfinder.domain.container.dto
+
+import com.yapp.itemfinder.domain.container.ContainerEntity
+
+data class ContainerResponse(
+    val id: Long,
+    val icon: String,
+    val spaceId: Long,
+    val name: String,
+    val defaultItemType: String,
+    val description: String? = null,
+    val imageUrl: String? = null
+) {
+    constructor(containerEntity: ContainerEntity) : this(
+        containerEntity.id,
+        containerEntity.iconType.name,
+        containerEntity.space.id,
+        containerEntity.name,
+        containerEntity.defaultItemType.name,
+        containerEntity.imageUrl
+    )
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -1,5 +1,6 @@
 package com.yapp.itemfinder.domain.container.service
 
+import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -9,12 +10,8 @@ import org.springframework.transaction.annotation.Transactional
 class ContainerService(
     private val containerRepository: ContainerRepository
 ) {
-    fun getSpaceIdToContainerIconNames(spaceIds: List<Long>): Map<Long, List<String>> {
-        val spaceIdWithContainerIcon = containerRepository.findIconTypeBySpaceIdIsIn(spaceIds)
-        val spaceIdToContainerIconNames = spaceIdWithContainerIcon.groupBy { it.spaceId }
-            .mapValues { (_, spaceIdToContainerIconType) ->
-                spaceIdToContainerIconType.map { it.iconType.name }
-            }
-        return spaceIdToContainerIconNames
+    fun getSpaceIdToContainers(spaceIds: List<Long>): Map<Long, List<ContainerEntity>> {
+        return containerRepository.findBySpaceIdIsIn(spaceIds)
+            .groupBy { it.space.id }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -1,0 +1,20 @@
+package com.yapp.itemfinder.domain.container.service
+
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class ContainerService(
+    private val containerRepository: ContainerRepository
+) {
+    fun getSpaceIdToContainerIconNames(spaceIds: List<Long>): Map<Long, List<String>> {
+        val spaceIdWithContainerIcon = containerRepository.findIconTypeBySpaceIdIsIn(spaceIds)
+        val spaceIdToContainerIconNames = spaceIdWithContainerIcon.groupBy { it.spaceId }
+            .mapValues { (_, spaceIdToContainerIconType) ->
+                spaceIdToContainerIconType.map { it.iconType.name }
+            }
+        return spaceIdToContainerIconNames
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -1,8 +1,43 @@
 package com.yapp.itemfinder.domain.space
 
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.itemfinder.domain.container.QContainerEntity.containerEntity
+import com.yapp.itemfinder.domain.space.QSpaceEntity.spaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface SpaceRepository : JpaRepository<SpaceEntity, Long> {
+interface SpaceRepository : JpaRepository<SpaceEntity, Long>, SpaceRepositorySupport {
     fun findByMemberIdAndName(memberId: Long, name: String): SpaceEntity?
     fun findByMemberId(memberId: Long): List<SpaceEntity>
 }
+
+interface SpaceRepositorySupport {
+    fun getSpaceWithContainerCountByMemberId(memberId: Long): List<SpaceWithContainerCount>
+}
+
+class SpaceRepositorySupportImpl(
+    private val queryFactory: JPAQueryFactory
+): SpaceRepositorySupport {
+    override fun getSpaceWithContainerCountByMemberId(memberId: Long): List<SpaceWithContainerCount> {
+        return queryFactory.select(
+                Projections.constructor(
+                    SpaceWithContainerCount::class.java,
+                    spaceEntity.id,
+                    spaceEntity.name,
+                    containerEntity.id.count()
+                )
+            )
+            .from(spaceEntity)
+            .leftJoin(containerEntity).on(containerEntity.space.id.eq(spaceEntity.id))
+            .where(spaceEntity.member.id.eq(memberId))
+            .groupBy(spaceEntity.id)
+            .orderBy(spaceEntity.createdAt.asc())
+            .fetch()
+    }
+}
+
+data class SpaceWithContainerCount(
+    val spaceId: Long,
+    val spaceName: String,
+    val containerCount: Long
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -17,16 +17,16 @@ interface SpaceRepositorySupport {
 
 class SpaceRepositorySupportImpl(
     private val queryFactory: JPAQueryFactory
-): SpaceRepositorySupport {
+) : SpaceRepositorySupport {
     override fun getSpaceWithContainerCountByMemberId(memberId: Long): List<SpaceWithContainerCount> {
         return queryFactory.select(
-                Projections.constructor(
-                    SpaceWithContainerCount::class.java,
-                    spaceEntity.id,
-                    spaceEntity.name,
-                    containerEntity.id.count()
-                )
+            Projections.constructor(
+                SpaceWithContainerCount::class.java,
+                spaceEntity.id,
+                spaceEntity.name,
+                containerEntity.id.count()
             )
+        )
             .from(spaceEntity)
             .innerJoin(containerEntity).on(containerEntity.space.id.eq(spaceEntity.id))
             .where(spaceEntity.member.id.eq(memberId))

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -28,7 +28,7 @@ class SpaceRepositorySupportImpl(
                 )
             )
             .from(spaceEntity)
-            .leftJoin(containerEntity).on(containerEntity.space.id.eq(spaceEntity.id))
+            .innerJoin(containerEntity).on(containerEntity.space.id.eq(spaceEntity.id))
             .where(spaceEntity.member.id.eq(memberId))
             .groupBy(spaceEntity.id)
             .orderBy(spaceEntity.createdAt.asc())

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
@@ -5,7 +5,7 @@ import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import com.yapp.itemfinder.domain.space.service.SpaceService
 import com.yapp.itemfinder.domain.member.MemberEntity
-import com.yapp.itemfinder.domain.space.dto.SpaceWithContainerIcon
+import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -30,9 +30,9 @@ class SpaceController(
         return spaceService.getSpaces(member.id)
     }
 
-    @Operation(summary = "멤버가 등록한 공간들에 대한 보관함 개수 및 상위 아이콘 리스트 조회")
-    @GetMapping("/spaces/container-icons")
-    fun getSpaceWithContainerIcons(@LoginMember member: MemberEntity): List<SpaceWithContainerIcon> {
-        return spaceService.getSpaceWithContainerIcons(member.id)
+    @Operation(summary = "멤버가 등록한 공간들에 대한 보관함 개수 및 보관함 정보 리스트 조회")
+    @GetMapping("/spaces/containers")
+    fun getSpaceWithTopContainers(@LoginMember member: MemberEntity): List<SpaceWithTopContainerResponse> {
+        return spaceService.getSpaceWithTopContainers(member.id)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
@@ -5,6 +5,7 @@ import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import com.yapp.itemfinder.domain.space.service.SpaceService
 import com.yapp.itemfinder.domain.member.MemberEntity
+import com.yapp.itemfinder.domain.space.dto.SpaceWithContainerIcon
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -27,5 +28,11 @@ class SpaceController(
     @GetMapping("/spaces")
     fun getSpaces(@LoginMember member: MemberEntity): SpacesResponse {
         return spaceService.getSpaces(member.id)
+    }
+
+    @Operation(summary = "멤버가 등록한 공간들에 대한 보관함 개수 및 상위 아이콘 리스트 조회")
+    @GetMapping("/spaces/container-icons")
+    fun getSpaceWithContainerIcons(@LoginMember member: MemberEntity): List<SpaceWithContainerIcon> {
+        return spaceService.getSpaceWithContainerIcons(member.id)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithContainerIcon.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithContainerIcon.kt
@@ -1,8 +1,0 @@
-package com.yapp.itemfinder.domain.space.dto
-
-data class SpaceWithContainerIcon(
-    val spaceId: Long,
-    val spaceName: String,
-    val containerCount: Long,
-    val containerIcons: List<String>
-)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithContainerIcon.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithContainerIcon.kt
@@ -1,0 +1,8 @@
+package com.yapp.itemfinder.domain.space.dto
+
+data class SpaceWithContainerIcon(
+    val spaceId: Long,
+    val spaceName: String,
+    val containerCount: Long,
+    val containerIcons: List<String>
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithTopContainerResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceWithTopContainerResponse.kt
@@ -1,0 +1,10 @@
+package com.yapp.itemfinder.domain.space.dto
+
+import com.yapp.itemfinder.domain.container.dto.ContainerResponse
+
+data class SpaceWithTopContainerResponse(
+    val spaceId: Long,
+    val spaceName: String,
+    val containerCount: Long,
+    val topContainers: List<ContainerResponse>
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -37,7 +37,7 @@ class SpaceService(
         val spaceWithContainerCount = spaceRepository.getSpaceWithContainerCountByMemberId(memberId)
         val spaceIdToContainerIconNames = containerService.getSpaceIdToContainerIconNames(spaceIds = spaceWithContainerCount.map { it.spaceId })
 
-        return spaceWithContainerCount.map {spaceWithCount ->
+        return spaceWithContainerCount.map { spaceWithCount ->
             SpaceWithContainerIcon(
                 spaceWithCount.spaceId,
                 spaceWithCount.spaceName,

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -2,6 +2,8 @@ package com.yapp.itemfinder
 
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.TestUtil.generateRandomString
+import com.yapp.itemfinder.domain.container.ContainerEntity
+import com.yapp.itemfinder.domain.container.IconType
 import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.member.Social
 import com.yapp.itemfinder.domain.member.SocialType
@@ -25,13 +27,27 @@ object FakeEntity {
     }
     fun createFakeSpaceEntity(
         id: Long = generateRandomPositiveLongValue(),
-        name: String = "공간 이름",
+        name: String = TestUtil.generateRandomString(30),
         member: MemberEntity,
     ): SpaceEntity {
         return SpaceEntity(
             id = id,
             name = name,
             member = member,
+        )
+    }
+
+    fun createFakeContainerEntity(
+        id: Long = generateRandomPositiveLongValue(),
+        name: String = "컨테이너 이름",
+        space: SpaceEntity,
+        iconType: IconType = IconType.IC_CONTAINER_1
+    ): ContainerEntity {
+        return ContainerEntity(
+            id = id,
+            name = name,
+            space = space,
+            iconType = iconType
         )
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -28,7 +28,7 @@ object FakeEntity {
     fun createFakeSpaceEntity(
         id: Long = generateRandomPositiveLongValue(),
         name: String = TestUtil.generateRandomString(30),
-        member: MemberEntity,
+        member: MemberEntity = createFakeMemberEntity(),
     ): SpaceEntity {
         return SpaceEntity(
             id = id,

--- a/src/test/kotlin/com/yapp/itemfinder/RepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/RepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.yapp.itemfinder
 
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(QuerydslTestConfig::class)
 annotation class RepositoryTest

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -14,7 +14,7 @@ class ContainerRepositoryTest(
     private val memberRepository: MemberRepository,
     private val spaceRepository: SpaceRepository,
     private val containerRepository: ContainerRepository,
-): BehaviorSpec({
+) : BehaviorSpec({
 
     Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
         val givenMember = memberRepository.save(createFakeMemberEntity())

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -1,0 +1,47 @@
+package com.yapp.itemfinder.domain.container
+
+import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
+import com.yapp.itemfinder.RepositoryTest
+import com.yapp.itemfinder.domain.member.MemberRepository
+import com.yapp.itemfinder.domain.space.SpaceRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+@RepositoryTest
+class ContainerRepositoryTest(
+    private val memberRepository: MemberRepository,
+    private val spaceRepository: SpaceRepository,
+    private val containerRepository: ContainerRepository,
+): BehaviorSpec({
+
+    Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
+        val givenMember = memberRepository.save(createFakeMemberEntity())
+        val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
+        val givenIconTypes = listOf(IconType.IC_CONTAINER_3, IconType.IC_CONTAINER_4)
+
+        repeat(2) {
+            containerRepository.save(
+                createFakeContainerEntity(space = givenSpace, iconType = givenIconTypes[it])
+            )
+        }
+
+        When("등록한 공간 아이디 리스트를 전달하면") {
+            val result = containerRepository.findIconTypeBySpaceIdIsIn(listOf(givenSpace.id))
+
+            Then("해당 공간들에 속한 보관함의 아이콘 값들을 찾아 반환한다") {
+                result.size shouldBe 2
+                with(result.first()) {
+                    spaceId shouldBe givenSpace.id
+                    iconType shouldBe givenIconTypes.first()
+                }
+
+                with(result.last()) {
+                    spaceId shouldBe givenSpace.id
+                    iconType shouldBe givenIconTypes.last()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -20,26 +20,31 @@ class ContainerRepositoryTest(
         val givenMember = memberRepository.save(createFakeMemberEntity())
         val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
         val givenIconTypes = listOf(IconType.IC_CONTAINER_3, IconType.IC_CONTAINER_4)
+        val givenContainers = mutableListOf<ContainerEntity>()
 
         repeat(2) {
             containerRepository.save(
                 createFakeContainerEntity(space = givenSpace, iconType = givenIconTypes[it])
-            )
+            ).also { container ->
+                givenContainers.add(container)
+            }
         }
 
         When("등록한 공간 아이디 리스트를 전달하면") {
-            val result = containerRepository.findIconTypeBySpaceIdIsIn(listOf(givenSpace.id))
+            val result = containerRepository.findBySpaceIdIsIn(listOf(givenSpace.id))
 
-            Then("해당 공간들에 속한 보관함의 아이콘 값들을 찾아 반환한다") {
+            Then("해당 공간들에 속한 보관함 정보들을 찾아 반환한다") {
                 result.size shouldBe 2
                 with(result.first()) {
-                    spaceId shouldBe givenSpace.id
+                    space.id shouldBe givenSpace.id
                     iconType shouldBe givenIconTypes.first()
+                    id shouldBe givenContainers.first().id
                 }
 
                 with(result.last()) {
-                    spaceId shouldBe givenSpace.id
+                    space.id shouldBe givenSpace.id
                     iconType shouldBe givenIconTypes.last()
+                    id shouldBe givenContainers.last().id
                 }
             }
         }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -1,0 +1,34 @@
+package com.yapp.itemfinder.domain.container.service
+
+import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.container.IconType
+import com.yapp.itemfinder.domain.container.SpaceIdWithContainerIcon
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+
+class ContainerServiceTest: BehaviorSpec({
+    val containerRepository = mockk<ContainerRepository>()
+    val containerService = ContainerService(containerRepository)
+
+    Given("특정 공간에 보관함이 등록되어 있을 때") {
+        val givenSpaceId = generateRandomPositiveLongValue()
+        val (givenSpace, givenIconType) = FakeEntity.createFakeSpaceEntity(id = givenSpaceId) to IconType.IC_CONTAINER_2
+        val givenContainer = FakeEntity.createFakeContainerEntity(space = givenSpace, iconType = givenIconType)
+        every { containerRepository.findIconTypeBySpaceIdIsIn(listOf(givenSpaceId)) } returns
+            listOf(SpaceIdWithContainerIcon(spaceId = givenSpaceId, iconType = givenIconType))
+
+        When("전달받은 공간 아이디 리스트에 대한 아이콘들을 조회했다면") {
+            val result = containerService.getSpaceIdToContainerIconNames(listOf(givenSpaceId))
+
+            Then("해당 아이콘의 이름을 map 형태(spaceId: 키, 아이콘 이름 배열: 값)로 변환해서 반환한다") {
+                result.keys.size shouldBe 1
+                result[givenSpaceId] shouldBe listOf(givenIconType.name)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -10,8 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 
-
-class ContainerServiceTest: BehaviorSpec({
+class ContainerServiceTest : BehaviorSpec({
     val containerRepository = mockk<ContainerRepository>()
     val containerService = ContainerService(containerRepository)
 
@@ -22,7 +21,7 @@ class ContainerServiceTest: BehaviorSpec({
         every { containerRepository.findIconTypeBySpaceIdIsIn(listOf(givenSpaceId)) } returns
             listOf(SpaceIdWithContainerIcon(spaceId = givenSpaceId, iconType = givenIconType))
 
-        When("전달받은 공간 아이디 리스트에 대한 아이콘들을 조회했다면") {
+        When("전달받은 공간 아이디 리스트에 대한 보관함 아이콘들을 조회했다면") {
             val result = containerService.getSpaceIdToContainerIconNames(listOf(givenSpaceId))
 
             Then("해당 아이콘의 이름을 map 형태(spaceId: 키, 아이콘 이름 배열: 값)로 변환해서 반환한다") {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -4,7 +4,7 @@ import com.yapp.itemfinder.FakeEntity
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.container.IconType
-import com.yapp.itemfinder.domain.container.SpaceIdWithContainerIcon
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -18,15 +18,17 @@ class ContainerServiceTest : BehaviorSpec({
         val givenSpaceId = generateRandomPositiveLongValue()
         val (givenSpace, givenIconType) = FakeEntity.createFakeSpaceEntity(id = givenSpaceId) to IconType.IC_CONTAINER_2
         val givenContainer = FakeEntity.createFakeContainerEntity(space = givenSpace, iconType = givenIconType)
-        every { containerRepository.findIconTypeBySpaceIdIsIn(listOf(givenSpaceId)) } returns
-            listOf(SpaceIdWithContainerIcon(spaceId = givenSpaceId, iconType = givenIconType))
+        every { containerRepository.findBySpaceIdIsIn(listOf(givenSpaceId)) } returns listOf(givenContainer)
 
-        When("전달받은 공간 아이디 리스트에 대한 보관함 아이콘들을 조회했다면") {
-            val result = containerService.getSpaceIdToContainerIconNames(listOf(givenSpaceId))
+        When("전달받은 공간 아이디 리스트에 대한 보관함 정보들을 조회했다면") {
+            val result = containerService.getSpaceIdToContainers(listOf(givenSpaceId))
 
-            Then("해당 아이콘의 이름을 map 형태(spaceId: 키, 아이콘 이름 배열: 값)로 변환해서 반환한다") {
-                result.keys.size shouldBe 1
-                result[givenSpaceId] shouldBe listOf(givenIconType.name)
+            Then("해당 아이콘의 이름을 map 형태(spaceId: 키, 보관한 엔티티: 값)로 변환해서 반환한다") {
+                assertSoftly {
+                    result.keys.size shouldBe 1
+                    result[givenSpaceId]?.size shouldBe 1
+                    result[givenSpaceId]?.first() shouldBe givenContainer
+                }
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -12,7 +12,7 @@ class SpaceRepositoryTest(
     private val memberRepository: MemberRepository,
     private val spaceRepository: SpaceRepository,
     private val containerRepository: ContainerRepository,
-): BehaviorSpec({
+) : BehaviorSpec({
 
     Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
         val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -31,6 +31,7 @@ class SpaceRepositoryTest(
 
         When("조회하고자 하는 대상 멤버 아이디를 전달한다면") {
             val result = spaceRepository.getSpaceWithContainerCountByMemberId(givenMember.id)
+
             Then("해당 회원이 등록한 각 공간에 등록된 보관함 개수를 확인할 수 있고, 각 공간들은 생성된 순서대로 조회된다") {
                 result.size shouldBe 2
                 with(result.first()) {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -1,0 +1,50 @@
+package com.yapp.itemfinder.domain.space
+
+import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.RepositoryTest
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.member.MemberRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+@RepositoryTest
+class SpaceRepositoryTest(
+    private val memberRepository: MemberRepository,
+    private val spaceRepository: SpaceRepository,
+    private val containerRepository: ContainerRepository,
+): BehaviorSpec({
+
+    Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
+        val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())
+        val firstSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
+        val secondSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
+
+        val (firstSpaceCount, secondSpaceCount) = 3 to 2
+
+        repeat(firstSpaceCount) {
+            containerRepository.save(FakeEntity.createFakeContainerEntity(space = firstSpace))
+        }
+
+        repeat(secondSpaceCount) {
+            containerRepository.save(FakeEntity.createFakeContainerEntity(space = secondSpace))
+        }
+
+        When("조회하고자 하는 대상 멤버 아이디를 전달한다면") {
+            val result = spaceRepository.getSpaceWithContainerCountByMemberId(givenMember.id)
+            Then("해당 회원이 등록한 각 공간에 등록된 보관함 개수를 확인할 수 있고, 각 공간들은 생성된 순서대로 조회된다") {
+                result.size shouldBe 2
+                with(result.first()) {
+                    containerCount shouldBe 3
+                    spaceId shouldBe firstSpace.id
+                    spaceName shouldBe firstSpace.name
+                }
+
+                with(result.last()) {
+                    containerCount shouldBe 2
+                    spaceId shouldBe secondSpace.id
+                    spaceName shouldBe secondSpace.name
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
@@ -2,7 +2,6 @@ package com.yapp.itemfinder.domain.space.service
 
 import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
-import com.yapp.itemfinder.TestUtil
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.api.exception.ConflictException
 import com.yapp.itemfinder.domain.container.IconType
@@ -105,8 +104,7 @@ class SpaceServiceTest : BehaviorSpec({
         When("유저가 등록한 공간에 보관함이 5개 이상 있다면") {
             val result = spaceService.getSpaceWithContainerIcons(givenMemberId)
 
-
-            Then("전달받은 보관함 아이콘 이름들 중 네 개까지만 잘라서 함께 값을 반환한다") {
+            Then("전달받은 보관함 아이콘들을 모두 전달하지 않고 중 최대 4개까지만 제한해서 전달한다") {
                 assertSoftly {
                     result.size shouldBe 1
                     with(result.first()) {


### PR DESCRIPTION
### 변경 내용 요약
홈화면 관련 API 추가

<details>
<summary>관련 화면 사진</summary>
<img width="408" alt="image" src="https://user-images.githubusercontent.com/63828890/211153546-4fac6b2e-e2f5-4feb-b90f-9832cce4fe54.png">
</details>

### 작업한 내용
- 유저가 등록한 공간들에 대해 각 공간에 포홤된 보관함 개수를 조회할 수 있습니다. (현재 공간은 공간을 등록한 순서(created_at)대로 조회되지만 추후 순서 저장 기능 구현 시 저장된 순서대로 조회되는 방향으로 수정될 예정입니다)
- 공간에 등록된 보관함들 또한 현재 보관함이 생성된 순서대로 조회되지만 추후 순서 기능 추가 후 상위 4개 순서에 해당하는 보관함을 조회하는 방향으로 수정될 예정입니다)
- 보관함에 신규 필드(icon_type)을 추가했습니다. 정해진 아이콘 개수는 현재 8개 입니다. 

#### API (홈화면 조회)
```
curl --location --request GET 'http://localhost:8080/spaces/containers' \
--header 'Authorization: Bearer token'
```
- response
```json
[
    {
        "spaceId": 11,
        "spaceName": "이름20",
        "containerCount": 1,
        "topContainers": [
            {
                "id": 1,
                "icon": "IC_CONTAINER_1",
                "spaceId": 11,
                "name": "container0 - 1",
                "defaultItemType": "FOOD",
                "description": null,
                "imageUrl": null
            }
        ]
    }
]
```

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-140)

### 기타 사항
기타 공유하고 싶은 점을 적어주세요.
