### PR TITLE
[A2Y-144] access token 재발급 api 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
@@ -31,3 +31,5 @@ class UnauthorizedException(
     message: String? = null,
     errorCode: ErrorCode? = null
 ) : BaseException(httpStatus, message, errorCode)
+
+const val INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다."

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
@@ -61,7 +61,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleJwtException(ex: JwtException): ResponseEntity<ErrorResponse> {
         logger.error("message=${ex.message}")
         return ResponseEntity.status(UNAUTHORIZED)
-            .body(ErrorResponse(message = "유효하지 않은 토큰입니다."))
+            .body(ErrorResponse(message = INVALID_TOKEN_MESSAGE))
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
@@ -2,9 +2,12 @@ package com.yapp.itemfinder.api.exception
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.security.SignatureException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -52,6 +55,13 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         logger.error("message=${ex.message}")
         return ResponseEntity.status(ex.httpStatus)
             .body(ErrorResponse(ex.message, ex.errorCode?.value))
+    }
+
+    @ExceptionHandler(JwtException::class, SignatureException::class)
+    fun handleJwtException(ex: JwtException): ResponseEntity<ErrorResponse> {
+        logger.error("message=${ex.message}")
+        return ResponseEntity.status(UNAUTHORIZED)
+            .body(ErrorResponse(message = "유효하지 않은 토큰입니다."))
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
@@ -2,7 +2,6 @@ package com.yapp.itemfinder.config
 
 import com.yapp.itemfinder.api.exception.UnauthorizedException
 import io.jsonwebtoken.Claims
-import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.io.Decoders
@@ -42,17 +41,6 @@ class JwtTokenProvider(
 
     fun getSubject(token: String): String {
         return getClaims(token).subject
-    }
-
-    /**
-     * 기한 만료 토큰으로부터 subject 반환
-     */
-    fun getSubjectFromExpiredToken(token: String): String {
-        return try {
-            getClaims(token).subject
-        } catch (e: ExpiredJwtException) {
-            e.claims.subject
-        }
     }
 
     private fun getClaims(token: String): Claims {

--- a/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
@@ -18,8 +18,8 @@ class JwtTokenProvider(
     private val secret: String
 ) {
     private val key: Key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secret))
-    val accessTokenExpirationMilliseconds: Long = 1000 * 60 * 60 * 12 // 12시간
-    val refreshTokenExpirationMilliseconds: Long = 1000 * 60 * 60 * 24 * 14 // 14일
+    val accessTokenExpirationMilliseconds: Long = 1000L * 60 * 60 * 12 // 12시간
+    val refreshTokenExpirationMilliseconds: Long = 1000L * 60 * 60 * 24 * 30 // 30일
 
     fun createAccessToken(subject: String): String {
         return createToken(subject, accessTokenExpirationMilliseconds)

--- a/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/JwtTokenProvider.kt
@@ -1,5 +1,6 @@
 package com.yapp.itemfinder.config
 
+import com.yapp.itemfinder.api.exception.INVALID_TOKEN_MESSAGE
 import com.yapp.itemfinder.api.exception.UnauthorizedException
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
@@ -50,8 +51,8 @@ class JwtTokenProvider(
                 .build()
                 .parseClaimsJws(token)
                 .body
-        } catch (e: IllegalArgumentException) {
-            throw UnauthorizedException(message = "토큰이 없습니다.")
+        } catch (e: Exception) {
+            throw UnauthorizedException(message = INVALID_TOKEN_MESSAGE)
         }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/auth/controller/AuthController.kt
@@ -6,6 +6,8 @@ import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.auth.service.AuthService
 import com.yapp.itemfinder.domain.auth.dto.LoginRequest
 import com.yapp.itemfinder.domain.auth.dto.LoginResponse
+import com.yapp.itemfinder.domain.auth.dto.ReissueRequest
+import com.yapp.itemfinder.domain.auth.dto.ReissueResponse
 import com.yapp.itemfinder.domain.auth.dto.SignUpRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -108,9 +110,37 @@ class AuthController(
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "null이거나 유효하지 않은 토큰"
+                description = "null이거나 유효하지 않은 토큰",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 회원",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             )
         ]
     )
     fun validateMember(@LoginMember member: MemberEntity) = "유효한 access token 입니다."
+
+    @PostMapping("/reissue")
+    @Operation(summary = "액세스 토큰 재발급")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200"
+            ),
+            ApiResponse(
+                responseCode = "401",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 회원",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun reissueAccessToken(@RequestBody request: ReissueRequest): ReissueResponse {
+        return authService.reissueToken(request)
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/auth/controller/AuthController.kt
@@ -132,11 +132,6 @@ class AuthController(
             ApiResponse(
                 responseCode = "401",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "존재하지 않는 회원",
-                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             )
         ]
     )

--- a/src/main/kotlin/com/yapp/itemfinder/domain/auth/dto/ReissueDtos.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/auth/dto/ReissueDtos.kt
@@ -1,0 +1,13 @@
+package com.yapp.itemfinder.domain.auth.dto
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+data class ReissueRequest(
+    val accessToken: String,
+    val refreshToken: String
+)
+
+@ApiResponse
+data class ReissueResponse(
+    val accessToken: String
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/auth/dto/ReissueDtos.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/auth/dto/ReissueDtos.kt
@@ -1,13 +1,9 @@
 package com.yapp.itemfinder.domain.auth.dto
 
-import io.swagger.v3.oas.annotations.responses.ApiResponse
-
 data class ReissueRequest(
-    val accessToken: String,
     val refreshToken: String
 )
 
-@ApiResponse
 data class ReissueResponse(
     val accessToken: String
 )

--- a/src/test/kotlin/com/yapp/itemfinder/JwtTokenUtil.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/JwtTokenUtil.kt
@@ -1,0 +1,24 @@
+package com.yapp.itemfinder
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import java.security.Key
+import java.util.Date
+
+object JwtTokenUtil {
+
+    private val key: Key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode("5dc5ef5de6e3094ec5fd308585eeff44950e9d8b87e95044bcbf7ec7200fd968632d73ee605c07df2a9d1f7dd6e5ced6903f9d029f682464079d311daeebb339"))
+
+    fun createToken(subject: String, expireMillis: Long): String {
+        val now = Date()
+        val expiration = Date(now.time + expireMillis)
+        return Jwts.builder()
+            .setSubject(subject)
+            .setIssuedAt(now)
+            .setExpiration(expiration)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact()
+    }
+}

--- a/src/test/kotlin/com/yapp/itemfinder/domain/auth/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/auth/service/AuthServiceTest.kt
@@ -3,6 +3,7 @@ package com.yapp.itemfinder.domain.auth.service
 import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 import com.yapp.itemfinder.JwtTokenUtil.createToken
 import com.yapp.itemfinder.api.exception.ConflictException
+import com.yapp.itemfinder.api.exception.UnauthorizedException
 import com.yapp.itemfinder.config.JwtTokenProvider
 import com.yapp.itemfinder.domain.auth.dto.LoginRequest
 import com.yapp.itemfinder.domain.auth.dto.ReissueRequest
@@ -13,7 +14,6 @@ import com.yapp.itemfinder.domain.member.SocialType
 import com.yapp.itemfinder.domain.auth.repository.TokenRepository
 import com.yapp.itemfinder.domain.member.MemberRepository
 import com.yapp.itemfinder.domain.token.TokenEntity
-import io.jsonwebtoken.ExpiredJwtException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -75,7 +75,7 @@ class AuthServiceTest() : BehaviorSpec({
         }
     }
 
-    Given("유효한 리프레시 토큰과 기한 만료된 액세스 토큰이 주어진 경우") {
+    Given("유효한 리프레시 토큰이 주어진 경우") {
         val member = createFakeMemberEntity()
 
         val refreshToken = createToken(member.id.toString(), 1000 * 60)
@@ -88,7 +88,6 @@ class AuthServiceTest() : BehaviorSpec({
 
             Then("액세스 토큰 재발급에 성공한다") {
                 reissueToken shouldNotBe null
-                println("reissueToken = $reissueToken")
             }
         }
     }
@@ -104,7 +103,7 @@ class AuthServiceTest() : BehaviorSpec({
             val reissueRequest = ReissueRequest(refreshToken)
 
             Then("액세스 토큰 재발급에 실패한다") {
-                shouldThrow<ExpiredJwtException> {
+                shouldThrow<UnauthorizedException> {
                     authService.reissueToken(request = reissueRequest)
                 }
             }


### PR DESCRIPTION
### 변경 내용 요약

액세스 토큰 재발급 api 추가

### 작업한 내용

- 액세스 토큰 재발급 api 추가
- GlobalExceptionHandler에 JwtException 핸들링 추가
- 리프레시 토큰 유효기간 수정: `30일`

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-144?atlOrigin=eyJpIjoiOGNjM2U4Yzc5NTJiNGQ5Yjg1N2U5MzFkMGE0ODdhZWMiLCJwIjoiaiJ9)

### 기타 사항

**200 Ok**

```json
{
  "accessToken": "새로 발급된 토큰"
}
```

**401 Unauthorized**
- 리프레시 토큰 만료된 경우
- 기타: 토큰이 존재하지 않는 경우, 잘못된 형식 등
