### PR TITLE
[A2Y-175] 공간 정책 변경으로 인해 공간 추가 API 수정 및 리팩토링

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -25,7 +25,7 @@ import javax.persistence.Table
 )
 class ContainerEntity(
     space: SpaceEntity,
-    name: String,
+    name: String = DEFAULT_CONTAINER_NAME,
     defaultItemType: ItemType = ItemType.LIFESTYLE,
     iconType: IconType = IconType.IC_CONTAINER_1,
     description: String? = null,
@@ -58,6 +58,9 @@ class ContainerEntity(
 
     var imageUrl: String? = imageUrl
         protected set
+    companion object {
+        const val DEFAULT_CONTAINER_NAME = "보관함"
+    }
 }
 
 enum class IconType(val value: Int) {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -1,6 +1,5 @@
 package com.yapp.itemfinder.domain.container.service
 
-import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,8 +9,11 @@ import org.springframework.transaction.annotation.Transactional
 class ContainerService(
     private val containerRepository: ContainerRepository
 ) {
-    fun getSpaceIdToContainers(spaceIds: List<Long>): Map<Long, List<ContainerEntity>> {
+    fun getSpaceIdToContainers(spaceIds: List<Long>): Map<Long, List<ContainerVo>> {
         return containerRepository.findBySpaceIdIsIn(spaceIds)
             .groupBy { it.space.id }
+            .mapValues { (_, containers) ->
+                containers.map { ContainerVo(it) }
+            }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -1,6 +1,8 @@
 package com.yapp.itemfinder.domain.container.service
 
+import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.space.SpaceEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,5 +17,10 @@ class ContainerService(
             .mapValues { (_, containers) ->
                 containers.map { ContainerVo(it) }
             }
+    }
+
+    fun addDefaultContainer(newSpace: SpaceEntity) {
+        val defaultContainer = ContainerEntity(space = newSpace)
+        containerRepository.save(defaultContainer)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerVo.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerVo.kt
@@ -1,11 +1,10 @@
-package com.yapp.itemfinder.domain.container.dto
+package com.yapp.itemfinder.domain.container.service
 
 import com.yapp.itemfinder.domain.container.ContainerEntity
-import com.yapp.itemfinder.domain.container.service.ContainerVo
 
-data class ContainerResponse(
+data class ContainerVo(
     val id: Long,
-    val icon: String,
+    val iconType: String,
     val spaceId: Long,
     val name: String,
     val defaultItemType: String,
@@ -14,21 +13,11 @@ data class ContainerResponse(
 ) {
     constructor(containerEntity: ContainerEntity) : this(
         id = containerEntity.id,
-        icon = containerEntity.iconType.name,
+        iconType = containerEntity.iconType.name,
         spaceId = containerEntity.space.id,
         name = containerEntity.name,
         defaultItemType = containerEntity.defaultItemType.name,
         description = containerEntity.description,
         imageUrl = containerEntity.imageUrl
-    )
-
-    constructor(containerVo: ContainerVo) : this(
-        id = containerVo.id,
-        icon = containerVo.iconType,
-        spaceId = containerVo.spaceId,
-        name = containerVo.name,
-        defaultItemType = containerVo.defaultItemType,
-        description = containerVo.description,
-        imageUrl = containerVo.imageUrl
     )
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
@@ -32,13 +32,17 @@ class SpaceEntity(
     var member: MemberEntity = member
         protected set
 
-    @Column(length = 30, nullable = false)
+    @Column(length = SPACE_NAME_LENGTH_LIMIT, nullable = false)
     var name: String = name
         protected set
 
     private fun validateName(name: String) {
-        require(name.isNotBlank() && name.length <= 30) {
-            throw BadRequestException(message = "1자 이상 30자 이내로 이름을 등록해 주세요.")
+        require(name.isNotBlank() && name.length <= SPACE_NAME_LENGTH_LIMIT) {
+            throw BadRequestException(message = "1자 이상 ${SPACE_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")
         }
+    }
+
+    companion object {
+        const val SPACE_NAME_LENGTH_LIMIT = 9
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceController.kt
@@ -5,6 +5,7 @@ import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import com.yapp.itemfinder.domain.space.service.SpaceService
 import com.yapp.itemfinder.domain.member.MemberEntity
+import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,8 +19,8 @@ class SpaceController(
 ) {
     @Operation(summary = "새로운 공간 등록")
     @PostMapping("/spaces")
-    fun createSpace(@LoginMember member: MemberEntity, @RequestBody createSpaceReq: CreateSpaceRequest) {
-        spaceService.createSpace(
+    fun createSpace(@LoginMember member: MemberEntity, @RequestBody createSpaceReq: CreateSpaceRequest): SpaceResponse {
+        return spaceService.createSpace(
             spaceRequest = createSpaceReq,
             member = member
         )

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/SpaceResponse.kt
@@ -3,21 +3,14 @@ package com.yapp.itemfinder.domain.space.dto
 import com.yapp.itemfinder.domain.space.SpaceEntity
 
 data class SpaceResponse(val name: String, val id: Long) {
-    companion object {
-        fun from(space: SpaceEntity): SpaceResponse {
-            return SpaceResponse(
-                name = space.name,
-                id = space.id
-            )
-        }
-    }
+    constructor(space: SpaceEntity) : this(space.name, space.id)
 }
 
 data class SpacesResponse(val spaces: List<SpaceResponse>) {
     companion object {
         fun from(spaces: List<SpaceEntity>): SpacesResponse {
             return SpacesResponse(
-                spaces = spaces.map { SpaceResponse.from(it) }
+                spaces = spaces.map { SpaceResponse(it) }
             )
         }
     }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -7,6 +7,7 @@ import com.yapp.itemfinder.domain.space.SpaceRepository
 import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.space.SpaceEntity
+import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import org.springframework.stereotype.Service
@@ -19,12 +20,12 @@ class SpaceService(
     private val containerService: ContainerService
 ) {
     @Transactional
-    fun createSpace(spaceRequest: CreateSpaceRequest, member: MemberEntity) {
+    fun createSpace(spaceRequest: CreateSpaceRequest, member: MemberEntity): SpaceResponse {
         val spaceName = spaceRequest.name
         validateSpaceExist(member.id, spaceName)
 
-        spaceRepository.save(
-            SpaceEntity(member = member, name = spaceName)
+        return SpaceResponse.from(
+            spaceRepository.save(SpaceEntity(member = member, name = spaceName))
         )
     }
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -24,9 +24,10 @@ class SpaceService(
         val spaceName = spaceRequest.name
         validateSpaceExist(member.id, spaceName)
 
-        return SpaceResponse.from(
-            spaceRepository.save(SpaceEntity(member = member, name = spaceName))
-        )
+        val newSpace = spaceRepository.save(SpaceEntity(member = member, name = spaceName))
+        return SpaceResponse(newSpace).also {
+            containerService.addDefaultContainer(newSpace)
+        }
     }
 
     fun getSpaces(memberId: Long): SpacesResponse {

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -8,6 +8,7 @@ import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.member.Social
 import com.yapp.itemfinder.domain.member.SocialType
 import com.yapp.itemfinder.domain.space.SpaceEntity
+import com.yapp.itemfinder.domain.space.SpaceEntity.Companion.SPACE_NAME_LENGTH_LIMIT
 import java.util.UUID
 
 object FakeEntity {
@@ -27,7 +28,7 @@ object FakeEntity {
     }
     fun createFakeSpaceEntity(
         id: Long = generateRandomPositiveLongValue(),
-        name: String = TestUtil.generateRandomString(30),
+        name: String = generateRandomString(SPACE_NAME_LENGTH_LIMIT),
         member: MemberEntity = createFakeMemberEntity(),
     ): SpaceEntity {
         return SpaceEntity(

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -42,13 +42,17 @@ object FakeEntity {
         id: Long = generateRandomPositiveLongValue(),
         name: String = "컨테이너 이름",
         space: SpaceEntity,
-        iconType: IconType = IconType.IC_CONTAINER_1
+        iconType: IconType = IconType.IC_CONTAINER_1,
+        description: String = "설명",
+        imageUrl: String = "image URL"
     ): ContainerEntity {
         return ContainerEntity(
             id = id,
             name = name,
             space = space,
-            iconType = iconType
+            iconType = iconType,
+            description = description,
+            imageUrl = imageUrl
         )
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -1,7 +1,10 @@
 package com.yapp.itemfinder.domain.container.service
 
-import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
+import com.yapp.itemfinder.domain.container.ContainerEntity
+import com.yapp.itemfinder.domain.container.ContainerEntity.Companion.DEFAULT_CONTAINER_NAME
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.container.IconType
 import io.kotest.assertions.assertSoftly
@@ -9,6 +12,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 
 class ContainerServiceTest : BehaviorSpec({
     val containerRepository = mockk<ContainerRepository>()
@@ -16,8 +20,8 @@ class ContainerServiceTest : BehaviorSpec({
 
     Given("특정 공간에 보관함이 등록되어 있을 때") {
         val givenSpaceId = generateRandomPositiveLongValue()
-        val (givenSpace, givenIconType) = FakeEntity.createFakeSpaceEntity(id = givenSpaceId) to IconType.IC_CONTAINER_2
-        val givenContainer = FakeEntity.createFakeContainerEntity(space = givenSpace, iconType = givenIconType)
+        val (givenSpace, givenIconType) = createFakeSpaceEntity(id = givenSpaceId) to IconType.IC_CONTAINER_2
+        val givenContainer = createFakeContainerEntity(space = givenSpace, iconType = givenIconType)
         every { containerRepository.findBySpaceIdIsIn(listOf(givenSpaceId)) } returns listOf(givenContainer)
 
         When("전달받은 공간 아이디 리스트에 대한 보관함 정보들을 조회했다면") {
@@ -37,6 +41,25 @@ class ContainerServiceTest : BehaviorSpec({
                         it.imageUrl shouldBe givenContainer.imageUrl
                     }
                 }
+            }
+        }
+    }
+
+    Given("새로운 공간이 생성되었을 때") {
+        val givenSpace = createFakeSpaceEntity()
+        val givenContainer = createFakeContainerEntity(space = givenSpace)
+        val containerCaptor = slot<ContainerEntity>()
+
+        every { containerRepository.save(capture(containerCaptor)) } returns givenContainer
+
+        When("해당 공간이 주어진다면") {
+            containerService.addDefaultContainer(newSpace = givenSpace)
+
+            Then("해당 공간에 대한 디폴트 보관함(기본 이름: 보관함, 기본 아이콘: 아이콘1) 을 생성 후 저장한다") {
+                containerCaptor.captured.space shouldBe givenSpace
+                containerCaptor.captured.name shouldBe DEFAULT_CONTAINER_NAME
+                containerCaptor.captured.name shouldBe "보관함"
+                containerCaptor.captured.iconType shouldBe IconType.IC_CONTAINER_1
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -27,7 +27,15 @@ class ContainerServiceTest : BehaviorSpec({
                 assertSoftly {
                     result.keys.size shouldBe 1
                     result[givenSpaceId]?.size shouldBe 1
-                    result[givenSpaceId]?.first() shouldBe givenContainer
+                    result[givenSpaceId]?.first()?.let {
+                        it.id shouldBe givenContainer.id
+                        it.spaceId shouldBe givenSpaceId
+                        it.iconType shouldBe givenContainer.iconType.name
+                        it.name shouldBe givenContainer.name
+                        it.defaultItemType shouldBe givenContainer.defaultItemType.name
+                        it.description shouldBe givenContainer.description
+                        it.imageUrl shouldBe givenContainer.imageUrl
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceEntityTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceEntityTest.kt
@@ -3,6 +3,7 @@ package com.yapp.itemfinder.domain.space
 import com.yapp.itemfinder.FakeEntity
 import com.yapp.itemfinder.TestUtil
 import com.yapp.itemfinder.api.exception.BadRequestException
+import com.yapp.itemfinder.domain.space.SpaceEntity.Companion.SPACE_NAME_LENGTH_LIMIT
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -13,8 +14,8 @@ class SpaceEntityTest : BehaviorSpec({
     Given("공간을 생성할 때") {
         val givenMember = FakeEntity.createFakeMemberEntity()
 
-        When("30자를 초과하거나 1자 미만 및 공백으로 구성된 공간 이름이 주어지면") {
-            val nameOverLengthLimit: String = TestUtil.generateRandomString(31)
+        When("제한된 글자를 초과하거나 1자 미만 및 공백으로 구성된 공간 이름이 주어지면") {
+            val nameOverLengthLimit: String = TestUtil.generateRandomString(SPACE_NAME_LENGTH_LIMIT + 1)
             val givenInvalidNames = listOf(nameOverLengthLimit, "", "  ")
 
             Then("해당 이름으로 공간을 생성할 수 없다") {
@@ -29,8 +30,8 @@ class SpaceEntityTest : BehaviorSpec({
             }
         }
 
-        When("1자 이상 30자 이하의 적절한 공간 이름이 주어지면") {
-            val givenValidNames = listOf(TestUtil.generateRandomString(30), "공간1", "공간2")
+        When("1자 이상 9자 이하의 적절한 공간 이름이 주어지면") {
+            val givenValidNames = listOf(TestUtil.generateRandomString(SPACE_NAME_LENGTH_LIMIT), "공간1", "공간2")
 
             Then("정상적으로 공간을 생성할 수 있다") {
                 givenValidNames.forAll { givenName ->

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/controller/SpaceControllerTest.kt
@@ -3,8 +3,10 @@ package com.yapp.itemfinder.domain.space.controller
 import com.yapp.itemfinder.ControllerIntegrationTest
 import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
+import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.get
@@ -54,13 +56,18 @@ class SpaceControllerTest : ControllerIntegrationTest() {
         // given
         val givenNonExistSpaceName = "새로운 공간명"
 
-        // when & expect
-        mockMvc.post("/spaces") {
+        // when
+        val mvcResult = mockMvc.post("/spaces") {
             contentType = MediaType.APPLICATION_JSON
             content = objectMapper.writeValueAsString(CreateSpaceRequest(givenNonExistSpaceName))
             accept = MediaType.APPLICATION_JSON
         }.andExpect {
             status { isOk() }
-        }
+        }.andReturn()
+
+        // then
+        val result = objectMapper.readValue(mvcResult.response.contentAsString, SpaceResponse::class.java)
+        result.id shouldNotBe null
+        result.name shouldBe givenNonExistSpaceName
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
@@ -27,7 +27,7 @@ import io.mockk.verify
 
 class SpaceServiceTest : BehaviorSpec({
     val spaceRepository = mockk<SpaceRepository>()
-    val containerService = mockk<ContainerService>()
+    val containerService = mockk<ContainerService>(relaxed = true)
     val spaceService = SpaceService(spaceRepository, containerService)
 
     Given("공간을 새로 추가할 때") {
@@ -58,7 +58,7 @@ class SpaceServiceTest : BehaviorSpec({
             every { spaceRepository.findByMemberIdAndName(givenMember.id, givenSpaceName) } returns null
             every { spaceRepository.save(capture(spaceCaptor)) } returns givenSpace
 
-            Then("정상적으로 해당 공간을 등록할 수 있다") {
+            Then("정상적으로 해당 공간을 등록하고 기본 보관함 생성을 요청할 수 있다") {
                 val response = spaceService.createSpace(givenCreateSpaceRequest, givenMember)
 
                 spaceCaptor.captured.name shouldBe givenSpaceName
@@ -66,6 +66,10 @@ class SpaceServiceTest : BehaviorSpec({
 
                 response.name shouldBe givenCreateSpaceRequest.name
                 response.id shouldBe givenSpace.id
+
+                verify(exactly = 1) {
+                    containerService.addDefaultContainer(givenSpace)
+                }
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
@@ -17,7 +17,6 @@ import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import com.yapp.itemfinder.domain.space.SpaceWithContainerCount
 import io.kotest.assertions.assertSoftly
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -53,16 +52,20 @@ class SpaceServiceTest : BehaviorSpec({
         }
 
         When("요청한 공간명으로 해당 유저가 등록한 공간이 존재하지 않는다면") {
+            val givenSpace = createFakeSpaceEntity(name = givenSpaceName, member = givenMember)
             val spaceCaptor = slot<SpaceEntity>()
+
             every { spaceRepository.findByMemberIdAndName(givenMember.id, givenSpaceName) } returns null
-            every { spaceRepository.save(capture(spaceCaptor)) } returns createFakeSpaceEntity(name = givenSpaceName, member = givenMember)
+            every { spaceRepository.save(capture(spaceCaptor)) } returns givenSpace
 
             Then("정상적으로 해당 공간을 등록할 수 있다") {
-                shouldNotThrow<Exception> {
-                    spaceService.createSpace(givenCreateSpaceRequest, givenMember)
-                }
+                val response = spaceService.createSpace(givenCreateSpaceRequest, givenMember)
+
                 spaceCaptor.captured.name shouldBe givenSpaceName
                 spaceCaptor.captured.member.id shouldBe givenMember.id
+
+                response.name shouldBe givenCreateSpaceRequest.name
+                response.id shouldBe givenSpace.id
             }
         }
     }


### PR DESCRIPTION
### 변경 내용 요약
공간 정책 변경으로 인해 공간 추가 API 수정 및 리팩토링

### 작업한 내용
- 멤버가 새로운 공간을 등록할 때 기본 보관함(이름: 보관함, 아이콘: 첫 번째 아이콘)이 생성되어야 합니다. (관련 정책 문서 [링크](https://www.notion.so/2e7b9343f16342829f423fa134c9dadc))
- 공간 이름은 최대 9글자까지 입력 가능하도록 수정되어 해당 부분 반영했습니다.
- 공간 추가 API의 Response가 필요해져 해당 Response를 아래와 같이 추가했습니다.
  ```json 
    {
        "name": "신규 공간 이름",
        "id": 3
    }
  ``` 
- 특정 공간에 해당하는 보관함 리스트 조회 시 ContainerEntity 대신 ContainerVo 객체들을 반환하도록 리팩토링했습니다.

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-175)

