### PR TITLE
[A2Y-131] 신규 보관함 추가 & 공간에 등록된 보관함 조회 api 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
@@ -1,6 +1,5 @@
-package com.yapp.itemfinder.domain.container.controller
+package com.yapp.itemfinder.api
 
-import com.yapp.itemfinder.api.LoginMember
 import com.yapp.itemfinder.domain.container.dto.ContainerResponse
 import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.container.service.ContainerService

--- a/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
@@ -4,6 +4,7 @@ import com.yapp.itemfinder.domain.container.dto.ContainerResponse
 import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.container.service.ContainerService
 import com.yapp.itemfinder.domain.member.MemberEntity
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -15,11 +16,13 @@ import javax.validation.Valid
 class ContainerController(
     private val containerService: ContainerService
 ) {
+    @Operation(summary = "특정 공간에 등록된 모든 보관함 조회")
     @GetMapping("/containers/by-space-id/{spaceId}")
     fun findContainersInSpace(@LoginMember member: MemberEntity, @PathVariable spaceId: Long): List<ContainerResponse> {
         return containerService.findContainersInSpace(member.id, spaceId)
     }
 
+    @Operation(summary = "새로운 보관함 등록")
     @PostMapping("/containers")
     fun createContainer(@LoginMember member: MemberEntity, @RequestBody @Valid createContainerReq: CreateContainerRequest): ContainerResponse {
         return containerService.createContainer(member.id, createContainerReq)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -38,7 +38,7 @@ class ContainerEntity(
     var space: SpaceEntity = space
         protected set
 
-    @Column(length = 30, nullable = false)
+    @Column(length = CONTAINER_NAME_LENGTH_LIMIT, nullable = false)
     var name: String = name
         protected set
 
@@ -60,6 +60,7 @@ class ContainerEntity(
         protected set
     companion object {
         const val DEFAULT_CONTAINER_NAME = "보관함"
+        const val CONTAINER_NAME_LENGTH_LIMIT = 15
     }
 }
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -1,15 +1,11 @@
 package com.yapp.itemfinder.domain.container
 
 import com.yapp.itemfinder.domain.BaseEntity
-import com.yapp.itemfinder.domain.item.ItemType
 import com.yapp.itemfinder.domain.space.SpaceEntity
-import org.hibernate.annotations.ColumnDefault
 import javax.persistence.AttributeConverter
 import javax.persistence.Column
 import javax.persistence.Convert
 import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.Index
 import javax.persistence.JoinColumn
@@ -26,9 +22,7 @@ import javax.persistence.Table
 class ContainerEntity(
     space: SpaceEntity,
     name: String = DEFAULT_CONTAINER_NAME,
-    defaultItemType: ItemType = ItemType.LIFESTYLE,
     iconType: IconType = IconType.IC_CONTAINER_1,
-    description: String? = null,
     imageUrl: String? = null,
     id: Long = 0L
 ) : BaseEntity(id) {
@@ -42,18 +36,9 @@ class ContainerEntity(
     var name: String = name
         protected set
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 20, nullable = false)
-    @ColumnDefault("'LIFESTYLE'")
-    var defaultItemType: ItemType = defaultItemType
-        protected set
-
     @Convert(converter = IconTypeConverter::class)
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     var iconType: IconType = iconType
-        protected set
-
-    var description: String? = description
         protected set
 
     var imageUrl: String? = imageUrl

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -1,9 +1,12 @@
 package com.yapp.itemfinder.domain.container
 
+import com.yapp.itemfinder.domain.space.SpaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     @Query("select c from ContainerEntity c where c.space.id in :spaceIds order by c.createdAt asc")
     fun findBySpaceIdIsIn(spaceIds: List<Long>): List<ContainerEntity>
+
+    fun findBySpaceOrderByCreatedAtAsc(space: SpaceEntity): List<ContainerEntity>
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -9,4 +9,5 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     fun findBySpaceIdIsIn(spaceIds: List<Long>): List<ContainerEntity>
 
     fun findBySpaceOrderByCreatedAtAsc(space: SpaceEntity): List<ContainerEntity>
+    fun findBySpaceIdAndName(spaceId: Long, name: String): ContainerEntity?
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/controller/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/controller/ContainerController.kt
@@ -1,0 +1,19 @@
+package com.yapp.itemfinder.domain.container.controller
+
+import com.yapp.itemfinder.api.LoginMember
+import com.yapp.itemfinder.domain.container.dto.ContainerResponse
+import com.yapp.itemfinder.domain.container.service.ContainerService
+import com.yapp.itemfinder.domain.member.MemberEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ContainerController(
+    private val containerService: ContainerService
+) {
+    @GetMapping("/containers/by-space-id/{spaceId}")
+    fun findContainersInSpace(@LoginMember member: MemberEntity, @PathVariable spaceId: Long): List<ContainerResponse> {
+        return containerService.findContainersInSpace(member.id, spaceId)
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/controller/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/controller/ContainerController.kt
@@ -2,11 +2,15 @@ package com.yapp.itemfinder.domain.container.controller
 
 import com.yapp.itemfinder.api.LoginMember
 import com.yapp.itemfinder.domain.container.dto.ContainerResponse
+import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.container.service.ContainerService
 import com.yapp.itemfinder.domain.member.MemberEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
 
 @RestController
 class ContainerController(
@@ -15,5 +19,10 @@ class ContainerController(
     @GetMapping("/containers/by-space-id/{spaceId}")
     fun findContainersInSpace(@LoginMember member: MemberEntity, @PathVariable spaceId: Long): List<ContainerResponse> {
         return containerService.findContainersInSpace(member.id, spaceId)
+    }
+
+    @PostMapping("/containers")
+    fun createContainer(@LoginMember member: MemberEntity, @RequestBody @Valid createContainerReq: CreateContainerRequest): ContainerResponse {
+        return containerService.createContainer(member.id, createContainerReq)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/ContainerResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/ContainerResponse.kt
@@ -8,8 +8,6 @@ data class ContainerResponse(
     val icon: String,
     val spaceId: Long,
     val name: String,
-    val defaultItemType: String,
-    val description: String? = null,
     val imageUrl: String? = null
 ) {
     constructor(containerEntity: ContainerEntity) : this(
@@ -17,8 +15,6 @@ data class ContainerResponse(
         icon = containerEntity.iconType.name,
         spaceId = containerEntity.space.id,
         name = containerEntity.name,
-        defaultItemType = containerEntity.defaultItemType.name,
-        description = containerEntity.description,
         imageUrl = containerEntity.imageUrl
     )
 
@@ -27,8 +23,6 @@ data class ContainerResponse(
         icon = containerVo.iconType,
         spaceId = containerVo.spaceId,
         name = containerVo.name,
-        defaultItemType = containerVo.defaultItemType,
-        description = containerVo.description,
         imageUrl = containerVo.imageUrl
     )
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
@@ -10,7 +10,6 @@ import javax.validation.constraints.Size
 
 class CreateContainerRequest(
     val spaceId: Long,
-
     @field:NotBlank
     @field:Size(min = 1, max = CONTAINER_NAME_LENGTH_LIMIT, message = "1자 이상 ${CONTAINER_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")
     val name: String,
@@ -18,7 +17,6 @@ class CreateContainerRequest(
     private val _icon: String,
     @field:URL(message = "올바른 URL 형식이어야 합니다")
     val url: String? = null,
-    val description: String? = null
 ) {
     val icon: IconType by lazy {
         IconType.values().firstOrNull { it.name == _icon } ?: throw BadRequestException(message = "올바르지 않은 아이콘입니다")

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
@@ -5,10 +5,13 @@ import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerEntity.Companion.CONTAINER_NAME_LENGTH_LIMIT
 import com.yapp.itemfinder.domain.container.IconType
 import org.hibernate.validator.constraints.URL
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
 
 class CreateContainerRequest(
     val spaceId: Long,
+
+    @field:NotBlank
     @field:Size(min = 1, max = CONTAINER_NAME_LENGTH_LIMIT, message = "1자 이상 ${CONTAINER_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")
     val name: String,
     @JsonProperty(value = "icon")

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/CreateContainerRequest.kt
@@ -1,0 +1,23 @@
+package com.yapp.itemfinder.domain.container.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.yapp.itemfinder.api.exception.BadRequestException
+import com.yapp.itemfinder.domain.container.ContainerEntity.Companion.CONTAINER_NAME_LENGTH_LIMIT
+import com.yapp.itemfinder.domain.container.IconType
+import org.hibernate.validator.constraints.URL
+import javax.validation.constraints.Size
+
+class CreateContainerRequest(
+    val spaceId: Long,
+    @field:Size(min = 1, max = CONTAINER_NAME_LENGTH_LIMIT, message = "1자 이상 ${CONTAINER_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")
+    val name: String,
+    @JsonProperty(value = "icon")
+    private val _icon: String,
+    @field:URL(message = "올바른 URL 형식이어야 합니다")
+    val url: String? = null,
+    val description: String? = null
+) {
+    val icon: IconType by lazy {
+        IconType.values().firstOrNull { it.name == _icon } ?: throw BadRequestException(message = "올바르지 않은 아이콘입니다")
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -1,15 +1,19 @@
 package com.yapp.itemfinder.domain.container.service
 
+import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.container.dto.ContainerResponse
 import com.yapp.itemfinder.domain.space.SpaceEntity
+import com.yapp.itemfinder.domain.space.SpaceRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional(readOnly = true)
 @Service
 class ContainerService(
-    private val containerRepository: ContainerRepository
+    private val containerRepository: ContainerRepository,
+    private val spaceRepository: SpaceRepository
 ) {
     fun getSpaceIdToContainers(spaceIds: List<Long>): Map<Long, List<ContainerVo>> {
         return containerRepository.findBySpaceIdIsIn(spaceIds)
@@ -22,5 +26,13 @@ class ContainerService(
     fun addDefaultContainer(newSpace: SpaceEntity) {
         val defaultContainer = ContainerEntity(space = newSpace)
         containerRepository.save(defaultContainer)
+    }
+
+    fun findContainersInSpace(requestMemberId: Long, spaceId: Long): List<ContainerResponse> {
+        val space = spaceRepository.findByIdAndMemberId(id = spaceId, memberId = requestMemberId)
+            ?: throw BadRequestException(message = "해당 유저가 등록한 공간이 없습니다")
+
+        return containerRepository.findBySpaceOrderByCreatedAtAsc(space)
+            .map { ContainerResponse(it) }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -47,7 +47,6 @@ class ContainerService(
             space = space,
             name = containerRequest.name,
             iconType = containerRequest.icon,
-            description = containerRequest.description,
             imageUrl = containerRequest.url
         )
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerVo.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerVo.kt
@@ -7,8 +7,6 @@ data class ContainerVo(
     val iconType: String,
     val spaceId: Long,
     val name: String,
-    val defaultItemType: String,
-    val description: String? = null,
     val imageUrl: String? = null
 ) {
     constructor(containerEntity: ContainerEntity) : this(
@@ -16,8 +14,6 @@ data class ContainerVo(
         iconType = containerEntity.iconType.name,
         spaceId = containerEntity.space.id,
         name = containerEntity.name,
-        defaultItemType = containerEntity.defaultItemType.name,
-        description = containerEntity.description,
         imageUrl = containerEntity.imageUrl
     )
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -2,6 +2,7 @@ package com.yapp.itemfinder.domain.space
 
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.QContainerEntity.containerEntity
 import com.yapp.itemfinder.domain.space.QSpaceEntity.spaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
@@ -12,6 +13,10 @@ interface SpaceRepository : JpaRepository<SpaceEntity, Long>, SpaceRepositorySup
     fun findByMemberId(memberId: Long): List<SpaceEntity>
     @Query("select s from SpaceEntity s where s.id = :id and s.member.id = :memberId")
     fun findByIdAndMemberId(id: Long, memberId: Long): SpaceEntity?
+}
+
+fun SpaceRepository.findByIdAndMemberIdOrThrowException(id: Long, memberId: Long): SpaceEntity {
+    return findByIdAndMemberId(id, memberId) ?: throw BadRequestException(message = "해당 유저가 등록한 공간이 없습니다")
 }
 
 interface SpaceRepositorySupport {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -5,10 +5,13 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.itemfinder.domain.container.QContainerEntity.containerEntity
 import com.yapp.itemfinder.domain.space.QSpaceEntity.spaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface SpaceRepository : JpaRepository<SpaceEntity, Long>, SpaceRepositorySupport {
     fun findByMemberIdAndName(memberId: Long, name: String): SpaceEntity?
     fun findByMemberId(memberId: Long): List<SpaceEntity>
+    @Query("select s from SpaceEntity s where s.id = :id and s.member.id = :memberId")
+    fun findByIdAndMemberId(id: Long, memberId: Long): SpaceEntity?
 }
 
 interface SpaceRepositorySupport {

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -43,7 +43,6 @@ object FakeEntity {
         name: String = "컨테이너 이름",
         space: SpaceEntity,
         iconType: IconType = IconType.IC_CONTAINER_1,
-        description: String = "설명",
         imageUrl: String = "image URL"
     ): ContainerEntity {
         return ContainerEntity(
@@ -51,7 +50,6 @@ object FakeEntity {
             name = name,
             space = space,
             iconType = iconType,
-            description = description,
             imageUrl = imageUrl
         )
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.yapp.itemfinder.RepositoryTest
 import com.yapp.itemfinder.domain.member.MemberRepository
 import com.yapp.itemfinder.domain.space.SpaceRepository
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.shouldBe
 
 @RepositoryTest
@@ -46,6 +47,31 @@ class ContainerRepositoryTest(
                     iconType shouldBe givenIconTypes.last()
                     id shouldBe givenContainers.last().id
                 }
+            }
+        }
+    }
+
+    Given("특정 공간에 여러 보관함이 저장되어 있을 때") {
+        val givenMember = memberRepository.save(createFakeMemberEntity())
+        val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
+        val (givenFirstContainer, givenSecondContainer) = containerRepository.save(createFakeContainerEntity(space = givenSpace)) to
+            containerRepository.save(createFakeContainerEntity(space = givenSpace))
+
+        When("보관함이 등록된 공간에 대한 보관함을 조회한다면") {
+            val result = containerRepository.findBySpaceOrderByCreatedAtAsc(givenSpace)
+
+            Then("공간에 등록된 보관함들이 생성된 순서대로 조회된다") {
+                result.size shouldBe 2
+                result shouldContainInOrder listOf(givenFirstContainer, givenSecondContainer)
+            }
+        }
+
+        When("보관함이 등록되지 않은 공간에 대한 보관함을 조회한다면") {
+            val anotherSpace = createFakeSpaceEntity(member = givenMember)
+            val result = containerRepository.findBySpaceOrderByCreatedAtAsc(anotherSpace)
+
+            Then("보관함이 조회되지 않는다") {
+                result shouldBe emptyList()
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -72,7 +72,7 @@ class ContainerServiceTest : BehaviorSpec({
     Given("공간에 등록된 보관함을 조회할 때") {
         val (givenMemberId, givenSpaceId) = generateRandomPositiveLongValue() to generateRandomPositiveLongValue()
 
-        When("요청한 유저가 전달한 공간 아이디로 실제 등록된 공간이 존재한다면") {
+        When("유저가 전달한 공간 아이디로 실제 등록된 공간이 존재한다면") {
             val givenSpace = createFakeSpaceEntity(id = givenSpaceId)
             val givenContainer = createFakeContainerEntity(space = givenSpace)
 
@@ -81,7 +81,7 @@ class ContainerServiceTest : BehaviorSpec({
 
             val response = containerService.findContainersInSpace(requestMemberId = givenMemberId, spaceId = givenSpaceId)
 
-            Then("해당하는 보관함 정보를 반환한다") {
+            Then("해당하는 공간에 등록된 보관함 정보들을 반환한다") {
                 response.size shouldBe 1
                 with(response.first()) {
                     id shouldBe givenContainer.id
@@ -111,7 +111,7 @@ class ContainerServiceTest : BehaviorSpec({
         When("요청한 보관함명과 동일한 이름으로 등록된 보관함이 이미 존재한다면") {
             every { containerRepository.findBySpaceIdAndName(givenSpaceId, givenCreateContainerRequest.name) } returns createFakeContainerEntity(space = givenSpace)
 
-            Then("해당 보관함을 추가할 수 있다") {
+            Then("해당 보관함을 추가할 수 없다") {
                 shouldThrow<ConflictException> {
                     containerService.createContainer(givenMemberId, givenCreateContainerRequest)
                 }
@@ -124,7 +124,7 @@ class ContainerServiceTest : BehaviorSpec({
             every { containerRepository.findBySpaceIdAndName(givenSpaceId, givenCreateContainerRequest.name) } returns null
             every { containerRepository.save(capture(containerCaptor)) } returns createFakeContainerEntity(space = givenSpace)
 
-            Then("해당 보관함을 공간에 추가할 수 없다") {
+            Then("해당 보관함을 공간에 추가할 수 있다") {
                 assertSoftly {
                     containerService.createContainer(givenMemberId, givenCreateContainerRequest)
                     with(containerCaptor.captured) {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -1,14 +1,17 @@
 package com.yapp.itemfinder.domain.container.service
 
 import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
-import com.yapp.itemfinder.api.exception.BadRequestException
+import com.yapp.itemfinder.api.exception.ConflictException
 import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerEntity.Companion.DEFAULT_CONTAINER_NAME
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.container.IconType
+import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.space.SpaceRepository
+import com.yapp.itemfinder.domain.space.findByIdAndMemberIdOrThrowException
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -18,8 +21,8 @@ import io.mockk.mockk
 import io.mockk.slot
 
 class ContainerServiceTest : BehaviorSpec({
-    val containerRepository = mockk<ContainerRepository>()
-    val spaceRepository = mockk<SpaceRepository>()
+    val containerRepository = mockk<ContainerRepository>(relaxed = true)
+    val spaceRepository = mockk<SpaceRepository>(relaxed = true)
     val containerService = ContainerService(containerRepository, spaceRepository)
 
     Given("특정 공간에 보관함이 등록되어 있을 때") {
@@ -71,16 +74,6 @@ class ContainerServiceTest : BehaviorSpec({
     Given("공간에 등록된 보관함을 조회할 때") {
         val (givenMemberId, givenSpaceId) = generateRandomPositiveLongValue() to generateRandomPositiveLongValue()
 
-        When("요청한 유저가 전달한 공간 아이디로 실제 등록된 공간이 존재하지 않는다면") {
-            every { spaceRepository.findByIdAndMemberId(id = givenSpaceId, memberId = givenMemberId) } returns null
-
-            Then("예외가 발생한다") {
-                shouldThrow<BadRequestException> {
-                    containerService.findContainersInSpace(requestMemberId = givenMemberId, spaceId = givenSpaceId)
-                }
-            }
-        }
-
         When("요청한 유저가 전달한 공간 아이디로 실제 등록된 공간이 존재한다면") {
             val givenSpace = createFakeSpaceEntity(id = givenSpaceId)
             val givenContainer = createFakeContainerEntity(space = givenSpace)
@@ -100,6 +93,52 @@ class ContainerServiceTest : BehaviorSpec({
                     defaultItemType shouldBe givenContainer.defaultItemType.name
                     description shouldBe givenContainer.description
                     imageUrl shouldBe givenContainer.imageUrl
+                }
+            }
+        }
+    }
+
+    Given("신규 보관함을 공간에 등록할 때") {
+        val (givenMemberId, givenSpaceId) = generateRandomPositiveLongValue() to generateRandomPositiveLongValue()
+        val givenMember = createFakeMemberEntity(id = givenMemberId)
+        val (givenSpace, givenIconType) = createFakeSpaceEntity(id = givenSpaceId, member = givenMember) to IconType.IC_CONTAINER_5
+
+        val givenCreateContainerRequest = CreateContainerRequest(
+            spaceId = givenSpaceId,
+            name = "name",
+            _icon = givenIconType.name,
+            url = "https://cdn.pixabay.com/photo/2016/03/28/12/35/cat-1285634_1280.png",
+            description = "description"
+        )
+
+        every { spaceRepository.findByIdAndMemberIdOrThrowException(givenSpaceId, givenMemberId) } returns givenSpace
+
+        When("요청한 보관함명과 동일한 이름으로 등록된 보관함이 이미 존재한다면") {
+            every { containerRepository.findBySpaceIdAndName(givenSpaceId, givenCreateContainerRequest.name) } returns createFakeContainerEntity(space = givenSpace)
+
+            Then("해당 보관함을 추가할 수 있다") {
+                shouldThrow<ConflictException> {
+                    containerService.createContainer(givenMemberId, givenCreateContainerRequest)
+                }
+            }
+        }
+
+        When("요청한 보관함명과 동일한 이름으로 등록된 보관함이 이미 존재하지 않는다면") {
+            val containerCaptor = slot<ContainerEntity>()
+
+            every { containerRepository.findBySpaceIdAndName(givenSpaceId, givenCreateContainerRequest.name) } returns null
+            every { containerRepository.save(capture(containerCaptor)) } returns createFakeContainerEntity(space = givenSpace)
+
+            Then("해당 보관함을 공간에 추가할 수 없다") {
+                assertSoftly {
+                    containerService.createContainer(givenMemberId, givenCreateContainerRequest)
+                    with(containerCaptor.captured) {
+                        space.id shouldBe givenSpaceId
+                        name shouldBe givenCreateContainerRequest.name
+                        iconType shouldBe givenIconType
+                        description shouldBe givenCreateContainerRequest.description
+                        imageUrl shouldBe givenCreateContainerRequest.url
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -43,8 +43,6 @@ class ContainerServiceTest : BehaviorSpec({
                         it.spaceId shouldBe givenSpaceId
                         it.iconType shouldBe givenContainer.iconType.name
                         it.name shouldBe givenContainer.name
-                        it.defaultItemType shouldBe givenContainer.defaultItemType.name
-                        it.description shouldBe givenContainer.description
                         it.imageUrl shouldBe givenContainer.imageUrl
                     }
                 }
@@ -90,8 +88,6 @@ class ContainerServiceTest : BehaviorSpec({
                     icon shouldBe givenContainer.iconType.name
                     spaceId shouldBe givenContainer.space.id
                     name shouldBe givenContainer.name
-                    defaultItemType shouldBe givenContainer.defaultItemType.name
-                    description shouldBe givenContainer.description
                     imageUrl shouldBe givenContainer.imageUrl
                 }
             }
@@ -108,7 +104,6 @@ class ContainerServiceTest : BehaviorSpec({
             name = "name",
             _icon = givenIconType.name,
             url = "https://cdn.pixabay.com/photo/2016/03/28/12/35/cat-1285634_1280.png",
-            description = "description"
         )
 
         every { spaceRepository.findByIdAndMemberIdOrThrowException(givenSpaceId, givenMemberId) } returns givenSpace
@@ -136,7 +131,6 @@ class ContainerServiceTest : BehaviorSpec({
                         space.id shouldBe givenSpaceId
                         name shouldBe givenCreateContainerRequest.name
                         iconType shouldBe givenIconType
-                        description shouldBe givenCreateContainerRequest.description
                         imageUrl shouldBe givenCreateContainerRequest.url
                     }
                 }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -84,7 +84,7 @@ class SpaceRepositoryTest(
         When("해당 회원이 등록하지 않은 공간에 대해 조회한다면") {
             val otherOtherSpaceId = generateRandomPositiveLongValue()
 
-            Then("조회한 결과가 없으므로 예외가 발생한다") {
+            Then("조회된 공간이 없으므로 예외가 발생한다") {
                 shouldThrow<BadRequestException> {
                     spaceRepository.findByIdAndMemberIdOrThrowException(id = otherOtherSpaceId, memberId = givenSavedMemberId)
                 }
@@ -94,7 +94,7 @@ class SpaceRepositoryTest(
         When("해당 회원이 등록한 공간에 대해 조회한다면") {
             val result = spaceRepository.findByIdAndMemberIdOrThrowException(id = givenSavedSpaceId, memberId = givenSavedMemberId)
 
-            Then("해당하는 공간의 정보를 반환한다") {
+            Then("조회된 공간이 있으므로 해당하는 공간의 정보를 반환한다") {
                 result shouldBe givenSpace
             }
         }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -1,11 +1,14 @@
 package com.yapp.itemfinder.domain.space
 
 import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.RepositoryTest
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.member.MemberRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity as createFakeMemberEntity1
 
 @RepositoryTest
 class SpaceRepositoryTest(
@@ -15,9 +18,9 @@ class SpaceRepositoryTest(
 ) : BehaviorSpec({
 
     Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
-        val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())
-        val firstSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
-        val secondSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
+        val givenMember = memberRepository.save(createFakeMemberEntity1())
+        val firstSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
+        val secondSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
 
         val (firstSpaceCount, secondSpaceCount) = 3 to 2
 
@@ -45,6 +48,28 @@ class SpaceRepositoryTest(
                     spaceId shouldBe secondSpace.id
                     spaceName shouldBe secondSpace.name
                 }
+            }
+        }
+    }
+
+    Given("회원이 특정 공간을 저장했을 때") {
+        val givenMember = memberRepository.save(createFakeMemberEntity1())
+        val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
+
+        When("해당하는 회원 아이디와 저장한 공간 아이디로 공간을 조회한다면") {
+            val result = spaceRepository.findByIdAndMemberId(givenSpace.id, givenMember.id)
+
+            Then("저장한 공간이 조회된다") {
+                result shouldBe givenSpace
+            }
+        }
+
+        When("해당하는 회원 아이디와 저장하지 않은 공간 아이디로 공간을 조회하면") {
+            val anotherSpaceId = generateRandomPositiveLongValue()
+            val result = spaceRepository.findByIdAndMemberId(anotherSpaceId, givenMember.id)
+
+            Then("공간이 조회되지 않는다") {
+                result shouldBe null
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceRepositoryTest.kt
@@ -10,7 +10,7 @@ import com.yapp.itemfinder.domain.member.MemberRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity as createFakeMemberEntity1
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 
 @RepositoryTest
 class SpaceRepositoryTest(
@@ -20,7 +20,7 @@ class SpaceRepositoryTest(
 ) : BehaviorSpec({
 
     Given("회원이 여러 공간에 해당하는 보관함을 등록했을 때") {
-        val givenMember = memberRepository.save(createFakeMemberEntity1())
+        val givenMember = memberRepository.save(createFakeMemberEntity())
         val firstSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
         val secondSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
 
@@ -55,7 +55,7 @@ class SpaceRepositoryTest(
     }
 
     Given("회원이 특정 공간을 저장했을 때") {
-        val givenMember = memberRepository.save(createFakeMemberEntity1())
+        val givenMember = memberRepository.save(createFakeMemberEntity())
         val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
 
         When("해당하는 회원 아이디와 저장한 공간 아이디로 공간을 조회한다면") {
@@ -77,7 +77,7 @@ class SpaceRepositoryTest(
     }
 
     Given("특정 회원이 특정 공간을 등록했을 때") {
-        val givenMember = memberRepository.save(createFakeMemberEntity1())
+        val givenMember = memberRepository.save(createFakeMemberEntity())
         val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
         val (givenSavedMemberId, givenSavedSpaceId) = givenMember.id to givenSpace.id
 

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
@@ -169,10 +169,8 @@ class SpaceServiceTest : BehaviorSpec({
                         topContainers.size shouldBe 1
                         topContainers[0].id shouldBe givenContainerVos[0].id
                         topContainers[0].icon shouldBe givenContainerVos[0].iconType
-                        topContainers[0].description shouldBe givenContainerVos[0].description
                         topContainers[0].imageUrl shouldBe givenContainerVos[0].imageUrl
                         topContainers[0].spaceId shouldBe givenContainerVos[0].spaceId
-                        topContainers[0].defaultItemType shouldBe givenContainerVos[0].defaultItemType
                     }
                 }
             }


### PR DESCRIPTION
### 변경 내용 요약
신규 보관함 추가 & 공간에 등록된 보관함 조회 api 추가

### 작업한 내용
- 신규 보관함 추가
  - 보관함 이름: 15자까지 제한 (1자 이상 15자 이내로 입력 가능합니다)
  - 이미 추가하려는 공간에 요청한 보관함 명으로 등록된 보관함이 존재한다면, 해당 보관함은 추가할 수 없습니다 (공간 내 보관함 명 중복 허용 X)
- 공간에 등록된 보관함 조회 api 추가
  - 보관함이 오래된 순으로 정렬해서 반환합니다. 
- ContainerEntity(보관함)에서 사용하지 않게 된 필드 삭제(description, defaultItemType)

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-131)

### 기타 사항
- 신규 보관함 추가 API
  - request
   ```curl
  curl --location --request POST 'http://localhost:8080/containers' \
  --header 'Authorization: Bearer token' \
  --header 'Content-Type: application/json' \
  --data-raw '{
      "name":"보관함명",
      "url": null, // null 허용
      "spaceId": 1,
      "icon": "IC_CONTAINER_1"
  }'
  ```
  - response
  ```json
  {
      "id": 17,
      "icon": "IC_CONTAINER_1",
      "spaceId": 1,
      "name": "보관함명",
      "imageUrl": null
  }
  ```
- 공간에 등록된 보관함 조회
  - response
  ```json
  [
      {
          "id": 1,
          "icon": "IC_CONTAINER_1",
          "spaceId": 1,
          "name": "name1",
          "imageUrl": null
      },
      {
          "id": 2,
          "icon": "IC_CONTAINER_1",
          "spaceId": 1,
          "name": "name2",
          "imageUrl": "https://cdn.pixabay.com/photo/2016/03/28/12/35/cat-1285634_1280.png"
      }
  ]
   ```
   

