### PR TITLE
[A2Y-199] AWS S3 연동 & 이미지 등록 api 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ val kotestVersion: String by project
 val mockkVersion: String by project
 val jjwtVersion: String by project
 val embeddedRedisVersion: String by project
+val springCloudAWSVersion: String by project
 
 plugins {
     id("org.springframework.boot") version "2.7.5"
@@ -63,6 +64,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+
+    // aws
+    implementation("io.awspring.cloud:spring-cloud-starter-aws:$springCloudAWSVersion")
 }
 
 noArg {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ val mockkVersion: String by project
 val jjwtVersion: String by project
 val embeddedRedisVersion: String by project
 val springCloudAWSVersion: String by project
+val s3MockVersion: String by project
 
 plugins {
     id("org.springframework.boot") version "2.7.5"
@@ -67,6 +68,8 @@ dependencies {
 
     // aws
     implementation("io.awspring.cloud:spring-cloud-starter-aws:$springCloudAWSVersion")
+    // s3 mock
+    implementation("io.findify:s3mock_2.13:$s3MockVersion")
 }
 
 noArg {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ kotestVersion = 4.4.3
 mockkVersion = 1.12.0
 jjwtVersion = 0.11.5
 embeddedRedisVersion = 0.7.2
+springCloudAWSVersion = 2.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ mockkVersion = 1.12.0
 jjwtVersion = 0.11.5
 embeddedRedisVersion = 0.7.2
 springCloudAWSVersion = 2.4.2
+s3MockVersion = 0.2.6

--- a/src/main/kotlin/com/yapp/itemfinder/api/AuthController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/AuthController.kt
@@ -1,6 +1,5 @@
-package com.yapp.itemfinder.domain.auth.controller
+package com.yapp.itemfinder.api
 
-import com.yapp.itemfinder.api.LoginMember
 import com.yapp.itemfinder.api.exception.ErrorResponse
 import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.auth.service.AuthService

--- a/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
@@ -1,0 +1,69 @@
+package com.yapp.itemfinder.api
+
+import com.yapp.itemfinder.api.exception.BadRequestException
+import com.yapp.itemfinder.api.exception.ErrorResponse
+import com.yapp.itemfinder.common.Const.ImageFormat
+import com.yapp.itemfinder.domain.member.MemberEntity
+import com.yapp.itemfinder.util.AmazonS3Uploader
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+const val INVALID_FILE_FORMAT = "잘못된 파일 형식입니다."
+
+@RestController
+@RequestMapping("/images")
+class ImageController(
+    private val amazonS3Uploader: AmazonS3Uploader
+) {
+    val fileMaxCnt = 1
+
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @Operation(summary = "이미지 파일 등록")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200"),
+            ApiResponse(
+                responseCode = "400",
+                description = "개수 초과 | 잘못된 파일 형식",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun addImage(
+        @LoginMember member: MemberEntity,
+        @Parameter(description = "multipart/form-data 형식의 이미지 리스트(개수 제한 10개).<br> key 값은 image.")
+        @RequestPart
+        image: List<MultipartFile>
+    ): List<ImageResponse> {
+        if (image.size > fileMaxCnt) {
+            throw BadRequestException(message = "파일은 최대 ${fileMaxCnt}개까지 업로드할 수 있습니다.")
+        }
+        image.map { validateImageFile(it) }
+        return image.map { ImageResponse(url = amazonS3Uploader.uploadFile(it)) }
+    }
+
+    private fun validateImageFile(file: MultipartFile) {
+        if (file.isEmpty) {
+            throw BadRequestException(message = INVALID_FILE_FORMAT)
+        }
+        val fileName = file.originalFilename
+            ?: throw BadRequestException(message = INVALID_FILE_FORMAT)
+        // 이미지 포맷 검사
+        val extension = fileName.split(".").last()
+        try {
+            enumValueOf<ImageFormat>(extension.uppercase())
+        } catch (e: IllegalArgumentException) {
+            throw BadRequestException(message = INVALID_FILE_FORMAT)
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
@@ -19,14 +19,13 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 const val INVALID_FILE_FORMAT = "잘못된 파일 형식입니다."
+const val FILE_MAX_AVAILABLE_COUNT = 10
 
 @RestController
 @RequestMapping("/images")
 class ImageController(
     private val amazonS3Uploader: AmazonS3Uploader
 ) {
-    val fileMaxCnt = 10
-
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "이미지 파일 등록")
     @ApiResponses(
@@ -41,15 +40,15 @@ class ImageController(
     )
     fun addImage(
         @LoginMember member: MemberEntity,
-        @Parameter(description = "multipart/form-data 형식의 이미지 리스트(개수 제한 10개).<br> key 값은 image.")
+        @Parameter(description = "multipart/form-data 형식의 이미지 리스트(개수 제한 10개).<br> key 값은 images.")
         @RequestPart
-        image: List<MultipartFile>
+        images: List<MultipartFile>
     ): List<ImageResponse> {
-        if (image.size > fileMaxCnt) {
-            throw BadRequestException(message = "파일은 최대 ${fileMaxCnt}개까지 업로드할 수 있습니다.")
+        if (images.size > FILE_MAX_AVAILABLE_COUNT) {
+            throw BadRequestException(message = "파일은 최대 ${FILE_MAX_AVAILABLE_COUNT}개까지 업로드할 수 있습니다.")
         }
-        image.map { validateImageFile(it) }
-        return image.map { ImageResponse(url = amazonS3Uploader.uploadFile(it)) }
+        images.map { validateImageFile(it) }
+        return images.map { ImageResponse(url = amazonS3Uploader.uploadFile(it)) }
     }
 
     private fun validateImageFile(file: MultipartFile) {

--- a/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ImageController.kt
@@ -25,7 +25,7 @@ const val INVALID_FILE_FORMAT = "잘못된 파일 형식입니다."
 class ImageController(
     private val amazonS3Uploader: AmazonS3Uploader
 ) {
-    val fileMaxCnt = 1
+    val fileMaxCnt = 10
 
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "이미지 파일 등록")

--- a/src/main/kotlin/com/yapp/itemfinder/api/ImageResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ImageResponse.kt
@@ -1,0 +1,5 @@
+package com.yapp.itemfinder.api
+
+data class ImageResponse(
+    val url: String
+)

--- a/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
@@ -1,6 +1,5 @@
-package com.yapp.itemfinder.domain.space.controller
+package com.yapp.itemfinder.api
 
-import com.yapp.itemfinder.api.LoginMember
 import com.yapp.itemfinder.domain.entity.space.dto.CreateSpaceRequest
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
 import com.yapp.itemfinder.domain.space.service.SpaceService

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
@@ -2,12 +2,9 @@ package com.yapp.itemfinder.api.exception
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
-import io.jsonwebtoken.JwtException
-import io.jsonwebtoken.security.SignatureException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
-import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -55,13 +52,6 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         logger.error("message=${ex.message}")
         return ResponseEntity.status(ex.httpStatus)
             .body(ErrorResponse(ex.message, ex.errorCode?.value))
-    }
-
-    @ExceptionHandler(JwtException::class, SignatureException::class)
-    fun handleJwtException(ex: JwtException): ResponseEntity<ErrorResponse> {
-        logger.error("message=${ex.message}")
-        return ResponseEntity.status(UNAUTHORIZED)
-            .body(ErrorResponse(message = INVALID_TOKEN_MESSAGE))
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/yapp/itemfinder/common/Const.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/common/Const.kt
@@ -5,4 +5,7 @@ import java.time.ZoneId
 object Const {
     val KST_ZONE_ID = ZoneId.of("Asia/Seoul")
     const val BEARER = "Bearer"
+    enum class ImageFormat {
+        JPEG, JPG, PNG
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/common/Const.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/common/Const.kt
@@ -6,6 +6,6 @@ object Const {
     val KST_ZONE_ID = ZoneId.of("Asia/Seoul")
     const val BEARER = "Bearer"
     enum class ImageFormat {
-        JPEG, JPG, PNG
+        JPEG, JPG, PNG, GIF
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/config/AmazonS3Config.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/AmazonS3Config.kt
@@ -1,0 +1,29 @@
+package com.yapp.itemfinder.config
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AmazonS3Config(
+    @Value("\${cloud.aws.credentials.access-key}")
+    private val accessKey: String,
+    @Value("\${cloud.aws.credentials.secret-key}")
+    private val secretKey: String,
+    @Value("\${cloud.aws.region.static}")
+    private val region: String
+) {
+
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val awsCredentials = BasicAWSCredentials(accessKey, secretKey)
+        return AmazonS3ClientBuilder.standard()
+            .withCredentials(AWSStaticCredentialsProvider(awsCredentials))
+            .withRegion(region)
+            .build() as AmazonS3Client
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/config/AmazonS3Config.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/AmazonS3Config.kt
@@ -7,7 +7,9 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
+@Profile("dev", "prod")
 @Configuration
 class AmazonS3Config(
     @Value("\${cloud.aws.credentials.access-key}")

--- a/src/main/kotlin/com/yapp/itemfinder/config/EmbeddedS3Config.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/config/EmbeddedS3Config.kt
@@ -1,0 +1,61 @@
+package com.yapp.itemfinder.config
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import io.findify.s3mock.S3Mock
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.web.util.UriComponentsBuilder
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+@Profile("local")
+@Configuration
+class EmbeddedS3Config(
+    @Value("\${cloud.aws.region.static}")
+    private val region: String,
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket: String,
+    @Value("\${cloud.aws.s3.mock.port}")
+    private val port: Int
+) {
+
+    private lateinit var s3Mock: S3Mock
+
+    @Bean
+    @Primary
+    fun amazonS3Client(): AmazonS3Client {
+        val endpoint = AwsClientBuilder.EndpointConfiguration(getUri(), region)
+        val client = AmazonS3ClientBuilder.standard()
+            .withPathStyleAccessEnabled(true)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
+            .build() as AmazonS3Client
+        client.createBucket(bucket)
+        return client
+    }
+
+    private fun getUri(): String {
+        return UriComponentsBuilder.newInstance().scheme("http").host("localhost").port(port).build().toUriString()
+    }
+
+    @PostConstruct
+    fun startS3Mock() {
+        s3Mock = S3Mock.Builder()
+            .withPort(port)
+            .withInMemoryBackend()
+            .build()
+        s3Mock.start()
+    }
+
+    @PreDestroy
+    fun destroyS3Mock() {
+        s3Mock.shutdown()
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
@@ -1,0 +1,41 @@
+package com.yapp.itemfinder.util
+
+import com.amazonaws.AmazonClientException
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.yapp.itemfinder.api.exception.BadRequestException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.IOException
+import java.util.*
+
+const val FILE_UPLOAD_FAIL = "파일 업로드 실패하였습니다."
+
+@Component
+class AmazonS3Uploader(
+    private val amazonS3Client: AmazonS3Client,
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucketName: String,
+) {
+    fun uploadFile(multipartFile: MultipartFile): String {
+        val originalFilename = multipartFile.originalFilename ?: throw BadRequestException()
+        val extension = originalFilename.split(".").last()
+        val fileName = "${UUID.randomUUID()}.$extension"
+
+        val objectMetadata = ObjectMetadata()
+        objectMetadata.contentType = multipartFile.contentType
+        objectMetadata.contentLength = multipartFile.size
+
+        try {
+            amazonS3Client.putObject(PutObjectRequest(bucketName, fileName, multipartFile.inputStream, objectMetadata))
+        } catch (e: IOException) {
+            throw BadRequestException(message = FILE_UPLOAD_FAIL)
+        } catch (e: AmazonClientException) {
+            throw BadRequestException(message = FILE_UPLOAD_FAIL)
+        }
+
+        return amazonS3Client.getResourceUrl(bucketName, fileName)
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
-import java.util.*
+import java.util.UUID
 
 const val FILE_UPLOAD_FAIL = "파일 업로드 실패하였습니다."
 

--- a/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/util/AmazonS3Uploader.kt
@@ -1,14 +1,15 @@
 package com.yapp.itemfinder.util
 
-import com.amazonaws.AmazonClientException
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.yapp.itemfinder.api.exception.BadRequestException
+import com.yapp.itemfinder.api.exception.BaseException
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
-import java.io.IOException
+import java.lang.Exception
 import java.util.UUID
 
 const val FILE_UPLOAD_FAIL = "파일 업로드 실패하였습니다."
@@ -30,12 +31,9 @@ class AmazonS3Uploader(
 
         try {
             amazonS3Client.putObject(PutObjectRequest(bucketName, fileName, multipartFile.inputStream, objectMetadata))
-        } catch (e: IOException) {
-            throw BadRequestException(message = FILE_UPLOAD_FAIL)
-        } catch (e: AmazonClientException) {
-            throw BadRequestException(message = FILE_UPLOAD_FAIL)
+        } catch (e: Exception) {
+            throw BaseException(httpStatus = INTERNAL_SERVER_ERROR, message = FILE_UPLOAD_FAIL)
         }
-
         return amazonS3Client.getResourceUrl(bucketName, fileName)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,10 +29,7 @@ spring:
   redis:
     host: localhost
     port: 6379
-
-  main:
-      allow-circular-references: true
-      
+    
 admin:
   username: "1"
   password: "test"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
       ddl-auto: none
     database-platform: org.hibernate.dialect.MariaDBDialect
 
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+      
 springdoc:
   api-docs:
     path: "/api-docs"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,9 @@ spring:
     host: localhost
     port: 6379
 
+  main:
+      allow-circular-references: true
+      
 admin:
   username: "1"
   password: "test"
@@ -35,7 +38,14 @@ logging:
 
 jwt:
     secret: 5dc5ef5de6e3094ec5fd308585eeff44950e9d8b87e95044bcbf7ec7200fd968632d73ee605c07df2a9d1f7dd6e5ced6903f9d029f682464079d311daeebb339
-
+    
+cloud:
+    aws:
+        region.static: ap-northeast-2
+        s3:
+            bucket: bucket
+            mock.port: 8001
+            
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,9 @@ cloud:
         s3:
             bucket: bucket
             mock.port: 8001
+        stack:
+            auto: false
+        
             
 ---
 spring:

--- a/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
@@ -1,0 +1,55 @@
+package com.yapp.itemfinder
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import io.findify.s3mock.S3Mock
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.web.util.UriComponentsBuilder
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+@TestConfiguration
+class AmazonS3TestConfig {
+    private val port = 8001
+    private val region = Regions.AP_NORTHEAST_2.name
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket = ""
+    private lateinit var s3Mock: S3Mock
+
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val endpoint = AwsClientBuilder.EndpointConfiguration(getUri(), region)
+        val client = AmazonS3ClientBuilder
+            .standard()
+            .withPathStyleAccessEnabled(true)
+            .withEndpointConfiguration(endpoint)
+            .withCredentials(AWSStaticCredentialsProvider(AnonymousAWSCredentials()))
+            .build() as AmazonS3Client
+        client.createBucket(bucket)
+        return client
+    }
+
+    private fun getUri(): String {
+        return UriComponentsBuilder.newInstance().scheme("http").host("localhost").port(port).build().toUriString()
+    }
+
+    @PostConstruct
+    fun startS3Mock() {
+        s3Mock = S3Mock.Builder()
+            .withPort(port)
+            .withInMemoryBackend()
+            .build()
+        s3Mock.start()
+    }
+
+    @PreDestroy
+    fun destroyS3Mock() {
+        s3Mock.shutdown()
+    }
+}

--- a/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
@@ -3,7 +3,6 @@ package com.yapp.itemfinder
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.AnonymousAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import io.findify.s3mock.S3Mock
@@ -17,7 +16,7 @@ import javax.annotation.PreDestroy
 @TestConfiguration
 class AmazonS3TestConfig {
     private val port = 8001
-    private val region = Regions.AP_NORTHEAST_2.name
+    private val region = "ap-northeast-2"
     @Value("\${cloud.aws.s3.bucket}")
     private val bucket = ""
     private lateinit var s3Mock: S3Mock

--- a/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/AmazonS3TestConfig.kt
@@ -14,11 +14,14 @@ import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
 
 @TestConfiguration
-class AmazonS3TestConfig {
-    private val port = 8001
-    private val region = "ap-northeast-2"
+class AmazonS3TestConfig(
+    @Value("\${cloud.aws.s3.mock.port}")
+    private val port: Int,
+    @Value("\${cloud.aws.region.static}")
+    private val region: String,
     @Value("\${cloud.aws.s3.bucket}")
-    private val bucket = ""
+    private val bucket: String
+) {
     private lateinit var s3Mock: S3Mock
 
     @Bean

--- a/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
@@ -22,7 +22,7 @@ import org.springframework.web.filter.CharacterEncodingFilter
 
 @SpringBootTest
 @Transactional
-@Import(EmbeddedRedisConfig::class)
+@Import(EmbeddedRedisConfig::class, AmazonS3TestConfig::class)
 abstract class ControllerIntegrationTest {
     @Autowired
     lateinit var objectMapper: ObjectMapper

--- a/src/test/kotlin/com/yapp/itemfinder/api/AuthControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/AuthControllerTest.kt
@@ -1,4 +1,4 @@
-package com.yapp.itemfinder.domain.auth.controller
+package com.yapp.itemfinder.api
 
 import com.yapp.itemfinder.ControllerIntegrationTest
 import com.yapp.itemfinder.domain.member.Social

--- a/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
@@ -15,7 +15,7 @@ class ImageControllerTest : ControllerIntegrationTest() {
     @Test
     fun `회원은 이미지를 등록할 수 있다`() {
         // given
-        val key = "image"
+        val key = "images"
         val multipartFile = MockMultipartFile(key, "imageName.png", IMAGE_PNG.mimeType, "test".toByteArray())
 
         // when
@@ -35,7 +35,7 @@ class ImageControllerTest : ControllerIntegrationTest() {
     @Test
     fun `이미지가 아닌 파일은 등록할 수 없다`() {
         // given
-        val key = "image"
+        val key = "images"
         val multipartFile = MockMultipartFile(key, "fileName.pdf", APPLICATION_PDF_VALUE, "test".toByteArray())
 
         // when

--- a/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
@@ -1,0 +1,82 @@
+package com.yapp.itemfinder.api
+
+import com.yapp.itemfinder.ControllerIntegrationTest
+import com.yapp.itemfinder.api.exception.ErrorResponse
+import io.kotest.matchers.shouldBe
+import org.apache.http.entity.ContentType.IMAGE_PNG
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.multipart
+
+class ImageControllerTest : ControllerIntegrationTest() {
+
+    @Test
+    fun `회원은 이미지를 등록할 수 있다`() {
+        // given
+        val key = "image"
+        val multipartFile = MockMultipartFile(key, "imageName.png", IMAGE_PNG.mimeType, "test".toByteArray())
+
+        // when
+        val result = mockMvc.multipart("/images") {
+            file(multipartFile)
+            contentType = MediaType.MULTIPART_FORM_DATA
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+        }.andReturn()
+
+        // then
+        val urlList = objectMapper.readValue(result.response.contentAsString, List::class.java)
+        urlList.size shouldBe 1
+    }
+
+    @Test
+    fun `이미지가 아닌 파일은 등록할 수 없다`() {
+        // given
+        val key = "image"
+        val multipartFile = MockMultipartFile(key, "fileName.pdf", APPLICATION_PDF_VALUE, "test".toByteArray())
+
+        // when
+        val result = mockMvc.multipart("/images") {
+            file(multipartFile)
+            contentType = MediaType.MULTIPART_FORM_DATA
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isBadRequest() }
+        }.andReturn()
+
+        // then
+        val errorResponse = objectMapper.readValue(result.response.contentAsString, ErrorResponse::class.java)
+        errorResponse.message shouldBe INVALID_FILE_FORMAT
+    }
+
+    @Test
+    fun `파일 개수가 10개를 초과하면 등록할 수 없다`() {
+        // given
+        val key = "image"
+        val multipartFile = MockMultipartFile(key, "fileName.pdf", APPLICATION_PDF_VALUE, "test".toByteArray())
+
+        // when & expect
+        mockMvc.multipart("/images") {
+            // 11개
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            file(multipartFile)
+            contentType = MediaType.MULTIPART_FORM_DATA
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isBadRequest() }
+        }
+    }
+}

--- a/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ImageControllerTest.kt
@@ -55,7 +55,7 @@ class ImageControllerTest : ControllerIntegrationTest() {
     @Test
     fun `파일 개수가 10개를 초과하면 등록할 수 없다`() {
         // given
-        val key = "image"
+        val key = "images"
         val multipartFile = MockMultipartFile(key, "fileName.pdf", APPLICATION_PDF_VALUE, "test".toByteArray())
 
         // when & expect

--- a/src/test/kotlin/com/yapp/itemfinder/api/SpaceControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/SpaceControllerTest.kt
@@ -1,4 +1,4 @@
-package com.yapp.itemfinder.domain.space.controller
+package com.yapp.itemfinder.api
 
 import com.yapp.itemfinder.ControllerIntegrationTest
 import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity

--- a/src/test/kotlin/com/yapp/itemfinder/api/ValidateMemberTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ValidateMemberTest.kt
@@ -1,4 +1,4 @@
-package com.yapp.itemfinder.domain.auth.controller
+package com.yapp.itemfinder.api
 
 import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 import com.yapp.itemfinder.common.Const.BEARER

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,5 +35,6 @@ cloud:
     aws:
         s3:
             bucket: bucket
+            region: ap-northeast-2
         stack:
             auto: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,9 +15,6 @@ spring:
   redis:
       host: localhost
       port: 6379
-  
-  main:
-      allow-circular-references: true
 
 admin:
   username: "test"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,6 +15,9 @@ spring:
   redis:
       host: localhost
       port: 6379
+  
+  main:
+      allow-circular-references: true
 
 admin:
   username: "test"
@@ -27,3 +30,8 @@ springdoc:
 
 jwt:
   secret: 5dc5ef5de6e3094ec5fd308585eeff44950e9d8b87e95044bcbf7ec7200fd968632d73ee605c07df2a9d1f7dd6e5ced6903f9d029f682464079d311daeebb339
+
+cloud:
+    aws:
+        s3:
+            bucket: bucket

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,3 +35,5 @@ cloud:
     aws:
         s3:
             bucket: bucket
+        stack:
+            auto: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,8 +30,9 @@ jwt:
 
 cloud:
     aws:
+        region.static: ap-northeast-2
         s3:
             bucket: bucket
-            region: ap-northeast-2
+            mock.port: 8001
         stack:
             auto: false


### PR DESCRIPTION
### 변경 내용 요약 
AWS S3 연동 & 이미지 등록 api 추가

### 작업한 내용
- AWS S3 연동
  - aws 관련 의존성 추가
  - dev, prod 환경 : s3 cloud storage에 연결
  - local 및 테스트 환경 : s3 mocking (in-memory로 동작) 
- 이미지 등록 api 추가
  - `jpg`, `jpeg`, `png`, `gif` 포맷의 이미지 파일만 허용
  - 한 요청당 최대 10개의 파일까지만 허용
  - 요청 사이즈는 최대 50MB까지 허용
  - 이미지는 `UUID.확장자` 이름으로 AWS S3 bucket에 저장됨

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-199?atlOrigin=eyJpIjoiNzZkNDZlOTBmMzYzNDkxMGI5MjY4MzMxOTdmYzEyNTciLCJwIjoiaiJ9)

### 기타 사항
- 이미지 등록 api
  - request
   ```
  curl -X 'POST' \
    'http://localhost:8080/images' \
    -H 'accept: */*' \
    -H 'Authorization: Bearer token' \
    -H 'Content-Type: multipart/form-data' \
    -F 'image=@fileName1.png;type=image/png' \
    -F 'image=@fileName2.png;type=image/png'
  ```
  - response
  ```json
  [
      {
          "url": "baseUrl/9d66755d-e1f1-4a64-8e8e-f2a06fb59c52.png"
      },
      {
          "url": "baseUrl/697dce0d-53b7-49f9-b4bf-a069d1c1b07e.png"
      }
  ]
  ```

- [application.yml](https://drive.google.com/file/d/1K_fKNZZn5W5qVKMniL3sHFDzFIPEqsRz/view?usp=sharing) 수정