### PR TITLE
fix: UrlValidator 관련 Spring profile 설정 수정

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/validation/UrlValidator.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/validation/UrlValidator.kt
@@ -33,7 +33,7 @@ class ImageUrlValidator(
     }
 }
 
-@Profile("!dev", "!prod")
+@Profile("!dev & !prod")
 @Component
 class SimpleUrlValidator : UrlValidator {
     override fun isValid(url: String): Boolean {


### PR DESCRIPTION
### 변경 내용 요약
UrlValidator 관련 Spring profile 설정 수정

### 작업한 내용
### AS IS
SimpleUrlValidator 빈이 dev 프로필이 아니거나 prod 프로필이 아니면 등록하도록 설정되어 있습니다.
ImageUrlValidator 빈은 dev 프로필이거나 prod 프로필이면 등록하도록 설정되어 있습니다.
따라서 dev 프로필이나 prod 프로필일 경우 UrlValidator에 대한 두 개의 빈이 등록되어 있고 빈 우선순위 설정이 되어 있지 않아 서버를 실행할 수 없습니다. 

### TO BE
SimpleUrlValidator 목적이 local, test 환경 즉 dev 프로필이 아니고, prod 프로필이 아닌 환경에서 등록하는 것이 목적이므로 Profile 관련 설정을 변경했습니다.
