### PR TITLE
[A2Y-219] 아이템 검색 API 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
@@ -4,7 +4,7 @@ import com.yapp.itemfinder.common.PageResponse
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.api.validation.UrlValidator
 import com.yapp.itemfinder.domain.item.ItemService
-import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
 import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
@@ -46,7 +46,7 @@ class ItemController(
         @LoginMember member: MemberEntity,
         @RequestParam(required = false, defaultValue = "0") @Min(0) page: Int,
         @RequestParam(required = false, defaultValue = "20") @Min(1) @Max(20) size: Int,
-        @RequestBody searchOption: SearchOption
+        @RequestBody searchOption: ItemSearchOption
     ): PageResponse<ItemOverviewResponse> {
         val pageRequest = PageRequest.of(page, size, searchOption.getSort())
         return itemService.search(searchOption, pageRequest, member.id)

--- a/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
@@ -1,20 +1,29 @@
 package com.yapp.itemfinder.api
 
+import com.yapp.itemfinder.common.PageResponse
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.api.validation.UrlValidator
 import com.yapp.itemfinder.domain.item.ItemService
+import com.yapp.itemfinder.domain.item.dto.SearchOption
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
+import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
 import com.yapp.itemfinder.domain.member.MemberEntity
 import io.swagger.v3.oas.annotations.Operation
+import org.springframework.data.domain.PageRequest
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 
 @RequestMapping("/items")
 @RestController
+@Validated
 class ItemController(
     private val itemService: ItemService,
     private val urlValidator: UrlValidator
@@ -29,5 +38,17 @@ class ItemController(
             throw BadRequestException(message = "url 형식이 올바르지 않습니다")
         }
         return itemService.createItem(createItemRequest, member.id)
+    }
+
+    @Operation(summary = "물건 검색")
+    @PostMapping("/search")
+    fun searchItems(
+        @LoginMember member: MemberEntity,
+        @RequestParam(required = false, defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(required = false, defaultValue = "20") @Min(1) @Max(20) size: Int,
+        @RequestBody searchOption: SearchOption
+    ): PageResponse<ItemOverviewResponse> {
+        val pageRequest = PageRequest.of(page, size, searchOption.getSort())
+        return itemService.search(searchOption, pageRequest, member.id)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
@@ -32,4 +32,10 @@ class UnauthorizedException(
     errorCode: ErrorCode? = null
 ) : BaseException(httpStatus, message, errorCode)
 
+class ForbiddenException(
+    httpStatus: HttpStatus = HttpStatus.FORBIDDEN,
+    message: String? = null,
+    errorCode: ErrorCode? = null
+) : BaseException(httpStatus, message, errorCode)
+
 const val INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다."

--- a/src/main/kotlin/com/yapp/itemfinder/common/DateTimeFormatter.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/common/DateTimeFormatter.kt
@@ -1,0 +1,7 @@
+package com.yapp.itemfinder.common
+
+import java.time.format.DateTimeFormatter
+
+object DateTimeFormatter {
+    val YYYYMMDD: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+}

--- a/src/main/kotlin/com/yapp/itemfinder/common/PageResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/common/PageResponse.kt
@@ -1,0 +1,19 @@
+package com.yapp.itemfinder.common
+
+import org.springframework.data.domain.Page
+
+data class PageResponse<T>(
+    val totalCount: Int,
+    val totalPages: Int,
+    val currentPageNumber: Int,
+    val hasNext: Boolean,
+    val data: List<T>
+) {
+    constructor(page: Page<T>) : this(
+        totalCount = page.totalElements.toInt(),
+        totalPages = page.totalPages,
+        currentPageNumber = page.pageable.pageNumber,
+        hasNext = page.hasNext(),
+        data = page.content
+    )
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -43,6 +43,11 @@ class ContainerEntity(
 
     var imageUrl: String? = imageUrl
         protected set
+
+    fun getCreatorId(): Long {
+        return space.getCreatorId()
+    }
+
     companion object {
         const val DEFAULT_CONTAINER_NAME = "보관함"
         const val CONTAINER_NAME_LENGTH_LIMIT = 15

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -17,4 +17,7 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     fun findByIdWithSpace(id: Long): ContainerEntity?
     @Query("select c from ContainerEntity c join fetch c.space where c.id = :id and c.space.member.id = :memberId")
     fun findWithSpaceByIdAndMemberId(id: Long, memberId: Long): ContainerEntity?
+
+    @Query("select c from ContainerEntity c join fetch c.space where c.space.member.id = :memberId")
+    fun findByMemberId(memberId: Long): List<ContainerEntity>
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -10,6 +10,8 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
 
     fun findBySpaceOrderByCreatedAtAsc(space: SpaceEntity): List<ContainerEntity>
     fun findBySpaceIdAndName(spaceId: Long, name: String): ContainerEntity?
+    @Query("select c from ContainerEntity c join fetch c.space s where c.id = :id")
+    fun findByIdWithSpace(id: Long): ContainerEntity?
     @Query("select c from ContainerEntity c join fetch c.space where c.id = :id and c.space.member.id = :memberId")
     fun findWithSpaceByIdAndMemberId(id: Long, memberId: Long): ContainerEntity?
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -9,6 +9,9 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     fun findBySpaceIdIsIn(spaceIds: List<Long>): List<ContainerEntity>
 
     fun findBySpaceOrderByCreatedAtAsc(space: SpaceEntity): List<ContainerEntity>
+
+    fun findBySpace(space: SpaceEntity): List<ContainerEntity>
+
     fun findBySpaceIdAndName(spaceId: Long, name: String): ContainerEntity?
     @Query("select c from ContainerEntity c join fetch c.space s where c.id = :id")
     fun findByIdWithSpace(id: Long): ContainerEntity?

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -37,12 +37,8 @@ class ItemRepositorySupportImpl(
         return paginationHelper.getPage(pageable, query, ItemEntity::class.java)
     }
 
-    private fun containerIdIsIn(targetContainerIds: List<Long>): BooleanExpression? {
-        return if (targetContainerIds.isNotEmpty()) {
-            itemEntity.container.id.`in`(targetContainerIds)
-        } else {
-            null
-        }
+    private fun containerIdIsIn(targetContainerIds: List<Long>): BooleanExpression {
+        return itemEntity.container.id.`in`(targetContainerIds)
     }
 
     private fun itemNameContains(itemName: String?): BooleanExpression? {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -6,7 +6,7 @@ import com.yapp.itemfinder.domain.item.QItemEntity.itemEntity
 import com.yapp.itemfinder.domain.item.dto.SearchOption
 import com.yapp.itemfinder.domain.tag.QItemTagEntity.itemTagEntity
 import com.yapp.itemfinder.domain.tag.QTagEntity.tagEntity
-import com.yapp.itemfinder.domain.support.PaginationHelper
+import com.yapp.itemfinder.support.PaginationHelper
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -3,7 +3,7 @@ package com.yapp.itemfinder.domain.item
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.itemfinder.domain.item.QItemEntity.itemEntity
-import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.tag.QItemTagEntity.itemTagEntity
 import com.yapp.itemfinder.domain.tag.QTagEntity.tagEntity
 import com.yapp.itemfinder.support.PaginationHelper
@@ -13,14 +13,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySupport
 interface ItemRepositorySupport {
-    fun search(searchOption: SearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity>
+    fun search(searchOption: ItemSearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity>
 }
 
 class ItemRepositorySupportImpl(
     private val queryFactory: JPAQueryFactory,
     private val paginationHelper: PaginationHelper
 ) : ItemRepositorySupport {
-    override fun search(searchOption: SearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity> {
+    override fun search(searchOption: ItemSearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity> {
         val query = queryFactory.select(itemEntity)
             .from(itemEntity)
             .leftJoin(itemEntity.tags, itemTagEntity)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -1,5 +1,71 @@
 package com.yapp.itemfinder.domain.item
 
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.itemfinder.domain.item.QItemEntity.itemEntity
+import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.tag.QItemTagEntity.itemTagEntity
+import com.yapp.itemfinder.domain.tag.QTagEntity.tagEntity
+import com.yapp.itemfinder.domain.support.PaginationHelper
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ItemRepository : JpaRepository<ItemEntity, Long>
+interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySupport
+interface ItemRepositorySupport {
+    fun search(searchOption: SearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity>
+}
+
+class ItemRepositorySupportImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val paginationHelper: PaginationHelper
+) : ItemRepositorySupport {
+    override fun search(searchOption: SearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity> {
+        val query = queryFactory.select(itemEntity)
+            .from(itemEntity)
+            .leftJoin(itemEntity.tags, itemTagEntity)
+            .leftJoin(itemTagEntity.tag, tagEntity)
+            .where(
+                containerIdIsIn(targetContainerIds),
+                itemTypeIsIn(searchOption.itemTypes),
+                tagNameIsIn(searchOption.tagNames),
+                itemNameContains(searchOption.itemName)
+            )
+            .groupBy(itemEntity.id)
+            .having(tagEntity.count().goe(searchOption.tagNames.size))
+
+        return paginationHelper.getPage(pageable, query, ItemEntity::class.java)
+    }
+
+    private fun containerIdIsIn(targetContainerIds: List<Long>): BooleanExpression? {
+        return if (targetContainerIds.isNotEmpty()) {
+            itemEntity.container.id.`in`(targetContainerIds)
+        } else {
+            null
+        }
+    }
+
+    private fun itemNameContains(itemName: String?): BooleanExpression? {
+        return if (!itemName.isNullOrBlank()) {
+            itemEntity.name.contains(itemName)
+        } else {
+            null
+        }
+    }
+
+    private fun itemTypeIsIn(itemTypes: List<ItemType>): BooleanExpression? {
+        return if (itemTypes.isNotEmpty()) {
+            itemEntity.type.`in`(itemTypes)
+        } else {
+            null
+        }
+    }
+
+    private fun tagNameIsIn(tagNames: List<String>): BooleanExpression? {
+        return if (tagNames.isNotEmpty()) {
+            tagEntity.name.`in`(tagNames)
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -53,7 +53,7 @@ class ItemService(
     fun search(searchOption: ItemSearchOption, pageRequest: PageRequest, memberId: Long): PageResponse<ItemOverviewResponse> {
         val targetContainerIds = searchOption.searchTarget?.let {
             findSearchTargetContainerIds(it.location, memberId, it.id)
-        } ?: emptyList()
+        } ?: containerRepository.findByMemberId(memberId).map { it.id }
 
         val pagedItems: Page<ItemEntity> = itemRepository.search(
             searchOption = searchOption,

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -75,7 +75,7 @@ class ItemService(
         return when (searchLocation) {
             SPACE -> {
                 val space = permissionValidator.validateSpaceByMemberId(memberId, targetId)
-                containerRepository.findBySpaceOrderByCreatedAtAsc(space).map { it.id }
+                containerRepository.findBySpace(space).map { it.id }
             }
             CONTAINER -> {
                 val container = permissionValidator.validateContainerByMemberId(memberId = memberId, containerId = targetId)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -7,9 +7,9 @@ import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
 import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
-import com.yapp.itemfinder.domain.item.dto.SearchTarget
-import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.CONTAINER
-import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.SPACE
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget.SearchLocation.CONTAINER
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget.SearchLocation.SPACE
 import com.yapp.itemfinder.support.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
 import org.springframework.data.domain.Page

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -10,7 +10,7 @@ import com.yapp.itemfinder.domain.item.dto.SearchOption
 import com.yapp.itemfinder.domain.item.dto.SearchTarget
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.CONTAINER
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.SPACE
-import com.yapp.itemfinder.domain.item.service.PermissionValidator
+import com.yapp.itemfinder.support.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -6,7 +6,7 @@ import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
 import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
-import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.SearchTarget
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.CONTAINER
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.SPACE
@@ -50,7 +50,7 @@ class ItemService(
         return ItemDetailResponse(item)
     }
 
-    fun search(searchOption: SearchOption, pageRequest: PageRequest, memberId: Long): PageResponse<ItemOverviewResponse> {
+    fun search(searchOption: ItemSearchOption, pageRequest: PageRequest, memberId: Long): PageResponse<ItemOverviewResponse> {
         val targetContainerIds = searchOption.searchTarget?.let {
             findSearchTargetContainerIds(it.location, memberId, it.id)
         } ?: emptyList()

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -1,10 +1,19 @@
 package com.yapp.itemfinder.domain.item
 
+import com.yapp.itemfinder.common.PageResponse
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
+import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
+import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.SearchTarget
+import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.CONTAINER
+import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation.SPACE
+import com.yapp.itemfinder.domain.item.service.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 class ItemService(
     private val itemRepository: ItemRepository,
     private val containerRepository: ContainerRepository,
-    private val itemTagService: ItemTagService
+    private val itemTagService: ItemTagService,
+    private val permissionValidator: PermissionValidator
 ) {
     @Transactional
     fun createItem(request: CreateItemRequest, memberId: Long): ItemDetailResponse {
@@ -38,5 +48,39 @@ class ItemService(
             itemTagService.createItemTags(item, request.tagIds, memberId)
         }
         return ItemDetailResponse(item)
+    }
+
+    fun search(searchOption: SearchOption, pageRequest: PageRequest, memberId: Long): PageResponse<ItemOverviewResponse> {
+        val targetContainerIds = searchOption.searchTarget?.let {
+            findSearchTargetContainerIds(it.location, memberId, it.id)
+        } ?: emptyList()
+
+        val pagedItems: Page<ItemEntity> = itemRepository.search(
+            searchOption = searchOption,
+            pageable = pageRequest,
+            targetContainerIds = targetContainerIds,
+        )
+
+        val itemIdToTagNames = itemTagService.createItemIdToTagNames(itemIds = pagedItems.content.map { it.id })
+        val maxTagNumberPerItem = 4
+        return PageResponse(
+            page = pagedItems.map {
+                val tagNames = itemIdToTagNames.getOrDefault(it.id, emptyList()).take(maxTagNumberPerItem)
+                ItemOverviewResponse(it, tagNames)
+            }
+        )
+    }
+
+    private fun findSearchTargetContainerIds(searchLocation: SearchTarget.SearchLocation, memberId: Long, targetId: Long): List<Long> {
+        return when (searchLocation) {
+            SPACE -> {
+                val space = permissionValidator.validateSpaceByMemberId(memberId, targetId)
+                containerRepository.findBySpaceOrderByCreatedAtAsc(space).map { it.id }
+            }
+            CONTAINER -> {
+                val container = permissionValidator.validateContainerByMemberId(memberId = memberId, containerId = targetId)
+                listOf(container.id)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemOverviewResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemOverviewResponse.kt
@@ -7,7 +7,7 @@ data class ItemOverviewResponse(
     val tags: List<String>,
     val id: Long,
     val name: String,
-    val quantity: Int = 0,
+    val quantity: Int,
     val itemType: String,
     val useByDate: String? = null,
     val representativeImageUrl: String? = null,

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemOverviewResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemOverviewResponse.kt
@@ -1,0 +1,32 @@
+package com.yapp.itemfinder.domain.item.dto
+
+import com.yapp.itemfinder.common.DateTimeFormatter.YYYYMMDD
+import com.yapp.itemfinder.domain.item.ItemEntity
+
+data class ItemOverviewResponse(
+    val tags: List<String>,
+    val id: Long,
+    val name: String,
+    val quantity: Int = 0,
+    val itemType: String,
+    val useByDate: String? = null,
+    val representativeImageUrl: String? = null,
+    val pinX: Float? = null,
+    val pinY: Float? = null,
+    val spaceName: String,
+    val containerName: String,
+) {
+    constructor(item: ItemEntity, tagNames: List<String>) : this(
+        tags = tagNames,
+        id = item.id,
+        name = item.name,
+        quantity = item.quantity,
+        itemType = item.type.name,
+        useByDate = item.dueDate?.format(YYYYMMDD),
+        representativeImageUrl = item.imageUrls.firstOrNull(),
+        pinX = item.itemPin?.positionX,
+        pinY = item.itemPin?.positionY,
+        spaceName = item.container.space.name,
+        containerName = item.container.name,
+    )
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
@@ -1,0 +1,44 @@
+package com.yapp.itemfinder.domain.item.dto
+
+import com.yapp.itemfinder.domain.item.ItemType
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+data class SearchOption(
+    val sortOrderOption: SortOrderOption = SortOrderOption.NameAsc,
+    val itemTypes: List<ItemType> = emptyList(),
+    val tagNames: List<String> = emptyList(),
+    val itemName: String? = null,
+    val searchTarget: SearchTarget? = null
+) {
+    fun toPageRequest(page: Int = 0, size: Int = 20): PageRequest {
+        return PageRequest.of(page, size, sortOrderOption.toSort())
+    }
+
+    fun getSort(): Sort {
+        return sortOrderOption.toSort()
+    }
+}
+
+data class SearchTarget(
+    val location: SearchLocation,
+    val id: Long
+) {
+    enum class SearchLocation {
+        SPACE, CONTAINER
+    }
+}
+
+enum class SortOrderOption(
+    private val targetField: String,
+    private val sortOrder: Sort.Direction
+) {
+    RecentCreated("createdAt", Sort.Direction.DESC),
+    PastCreated("createdAt", Sort.Direction.ASC),
+    NameAsc("name", Sort.Direction.ASC),
+    NameDesc("name", Sort.Direction.DESC);
+
+    fun toSort(): Sort {
+        return Sort.by(sortOrder, targetField)
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
@@ -1,20 +1,17 @@
 package com.yapp.itemfinder.domain.item.dto
 
 import com.yapp.itemfinder.domain.item.ItemType
-import org.springframework.data.domain.PageRequest
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.domain.Sort
 
 data class SearchOption(
-    val sortOrderOption: SortOrderOption = SortOrderOption.NameAsc,
+    val sortOrderOption: SortOrderOption = SortOrderOption.RecentCreated,
     val itemTypes: List<ItemType> = emptyList(),
     val tagNames: List<String> = emptyList(),
     val itemName: String? = null,
     val searchTarget: SearchTarget? = null
 ) {
-    fun toPageRequest(page: Int = 0, size: Int = 20): PageRequest {
-        return PageRequest.of(page, size, sortOrderOption.toSort())
-    }
-
+    @Hidden
     fun getSort(): Sort {
         return sortOrderOption.toSort()
     }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
@@ -4,7 +4,7 @@ import com.yapp.itemfinder.domain.item.ItemType
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.domain.Sort
 
-data class SearchOption(
+data class ItemSearchOption(
     val sortOrderOption: SortOrderOption = SortOrderOption.RecentCreated,
     val itemTypes: List<ItemType> = emptyList(),
     val tagNames: List<String> = emptyList(),

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemSearchOption.kt
@@ -15,27 +15,27 @@ data class ItemSearchOption(
     fun getSort(): Sort {
         return sortOrderOption.toSort()
     }
-}
 
-data class SearchTarget(
-    val location: SearchLocation,
-    val id: Long
-) {
-    enum class SearchLocation {
-        SPACE, CONTAINER
+    enum class SortOrderOption(
+        private val targetField: String,
+        private val sortOrder: Sort.Direction
+    ) {
+        RecentCreated("createdAt", Sort.Direction.DESC),
+        PastCreated("createdAt", Sort.Direction.ASC),
+        NameAsc("name", Sort.Direction.ASC),
+        NameDesc("name", Sort.Direction.DESC);
+
+        fun toSort(): Sort {
+            return Sort.by(sortOrder, targetField)
+        }
     }
-}
 
-enum class SortOrderOption(
-    private val targetField: String,
-    private val sortOrder: Sort.Direction
-) {
-    RecentCreated("createdAt", Sort.Direction.DESC),
-    PastCreated("createdAt", Sort.Direction.ASC),
-    NameAsc("name", Sort.Direction.ASC),
-    NameDesc("name", Sort.Direction.DESC);
-
-    fun toSort(): Sort {
-        return Sort.by(sortOrder, targetField)
+    data class SearchTarget(
+        val location: SearchLocation,
+        val id: Long
+    ) {
+        enum class SearchLocation {
+            SPACE, CONTAINER
+        }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidator.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidator.kt
@@ -1,0 +1,38 @@
+package com.yapp.itemfinder.domain.item.service
+
+import com.yapp.itemfinder.api.exception.ForbiddenException
+import com.yapp.itemfinder.api.exception.NotFoundException
+import com.yapp.itemfinder.domain.container.ContainerEntity
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.space.SpaceEntity
+import com.yapp.itemfinder.domain.space.SpaceRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(readOnly = true)
+class PermissionValidator(
+    private val containerRepository: ContainerRepository,
+    private val spaceRepository: SpaceRepository,
+) {
+    fun validateSpaceByMemberId(memberId: Long, spaceId: Long): SpaceEntity {
+        val space = spaceRepository.findByIdOrNull(spaceId) ?: throw NotFoundException(message = "해당 공간을 찾을 수 없습니다")
+        return space.also {
+            validateCreatorIdAndRequestId(it.getCreatorId(), memberId)
+        }
+    }
+
+    fun validateContainerByMemberId(memberId: Long, containerId: Long): ContainerEntity {
+        val container = containerRepository.findByIdWithSpace(containerId) ?: throw NotFoundException(message = "해당 보관함을 찾을 수 없습니다")
+        return container.also {
+            validateCreatorIdAndRequestId(it.getCreatorId(), memberId)
+        }
+    }
+
+    private fun validateCreatorIdAndRequestId(creatorMemberId: Long, requestMemberId: Long) {
+        if (creatorMemberId != requestMemberId) {
+            throw ForbiddenException(message = "해당 권한이 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
@@ -36,6 +36,10 @@ class SpaceEntity(
     var name: String = name
         protected set
 
+    fun getCreatorId(): Long {
+        return member.id
+    }
+
     private fun validateName(name: String) {
         require(name.isNotBlank() && name.length <= SPACE_NAME_LENGTH_LIMIT) {
             throw BadRequestException(message = "1자 이상 ${SPACE_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")

--- a/src/main/kotlin/com/yapp/itemfinder/domain/support/PaginationHelper.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/support/PaginationHelper.kt
@@ -1,0 +1,31 @@
+package com.yapp.itemfinder.domain.support
+
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.PathBuilderFactory
+import com.querydsl.jpa.JPQLQuery
+import com.querydsl.jpa.impl.JPAQuery
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.support.Querydsl
+import org.springframework.data.support.PageableExecutionUtils
+import org.springframework.stereotype.Component
+import javax.persistence.EntityManager
+
+@Component
+class PaginationHelper(
+    private val entityManager: EntityManager,
+) {
+    private fun getQuerydsl(domainClass: Class<*>): Querydsl {
+        return Querydsl(entityManager, PathBuilderFactory().create(domainClass))
+    }
+
+    fun <T> getPage(pageable: Pageable, query: JPAQuery<T>, domainClass: Class<*>): Page<T> {
+        val countQuery = query.clone(entityManager).select(Expressions.ONE) as JPQLQuery<*>
+
+        val content = getQuerydsl(domainClass)
+            .applyPagination(pageable, query)
+            .fetch()
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount)
+    }
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
@@ -13,4 +13,16 @@ interface ItemTagRepository : JpaRepository<ItemTagEntity, Long> {
             "group by it.tag, it.item.type"
     )
     fun findByTagIsInGroupByItemType(tags: List<TagEntity>): List<TagWithItemTypeDto>
+
+    @Query(
+        value = "select new com.yapp.itemfinder.domain.tag.ItemIdWithTagName(itemTag.item.id, tag.name) " +
+            "from ItemTagEntity itemTag inner join TagEntity tag on itemTag.tag = tag where itemTag.item.id in :itemIds"
+    )
+    fun findItemTagNameItemIdIsIn(itemIds: List<Long>): List<ItemIdWithTagName>
 }
+
+data class ItemIdWithTagName(
+    val itemId: Long,
+    val tagName: String
+)
+

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
@@ -25,4 +25,3 @@ data class ItemIdWithTagName(
     val itemId: Long,
     val tagName: String
 )
-

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
@@ -18,7 +18,7 @@ interface ItemTagRepository : JpaRepository<ItemTagEntity, Long> {
         value = "select new com.yapp.itemfinder.domain.tag.ItemIdWithTagName(itemTag.item.id, tag.name) " +
             "from ItemTagEntity itemTag inner join TagEntity tag on itemTag.tag = tag where itemTag.item.id in :itemIds"
     )
-    fun findItemTagNameItemIdIsIn(itemIds: List<Long>): List<ItemIdWithTagName>
+    fun findItemIdAndTagNameByItemIdIsIn(itemIds: List<Long>): List<ItemIdWithTagName>
 }
 
 data class ItemIdWithTagName(

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
@@ -30,7 +30,7 @@ class ItemTagService(
             return emptyMap()
         }
 
-        return itemTagRepository.findItemTagNameItemIdIsIn(itemIds)
+        return itemTagRepository.findItemIdAndTagNameByItemIdIsIn(itemIds)
             .groupBy { it.itemId }
             .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName } }
     }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
@@ -32,6 +32,6 @@ class ItemTagService(
 
         return itemTagRepository.findItemTagNameItemIdIsIn(itemIds)
             .groupBy { it.itemId }
-            .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName }}
+            .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName } }
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
@@ -24,4 +24,10 @@ class ItemTagService(
         item.updateTags(itemTags)
         return itemTags
     }
+
+    fun createItemIdToTagNames(itemIds: List<Long>): Map<Long, List<String>> {
+        return itemTagRepository.findItemTagNameItemIdIsIn(itemIds)
+            .groupBy { it.itemId }
+            .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName }}
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
@@ -26,6 +26,10 @@ class ItemTagService(
     }
 
     fun createItemIdToTagNames(itemIds: List<Long>): Map<Long, List<String>> {
+        if (itemIds.isEmpty()) {
+            return emptyMap()
+        }
+
         return itemTagRepository.findItemTagNameItemIdIsIn(itemIds)
             .groupBy { it.itemId }
             .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName }}

--- a/src/main/kotlin/com/yapp/itemfinder/support/PaginationHelper.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/support/PaginationHelper.kt
@@ -1,4 +1,4 @@
-package com.yapp.itemfinder.domain.support
+package com.yapp.itemfinder.support
 
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.PathBuilderFactory

--- a/src/main/kotlin/com/yapp/itemfinder/support/PermissionValidator.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/support/PermissionValidator.kt
@@ -1,4 +1,4 @@
-package com.yapp.itemfinder.domain.item.service
+package com.yapp.itemfinder.support
 
 import com.yapp.itemfinder.api.exception.ForbiddenException
 import com.yapp.itemfinder.api.exception.NotFoundException

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,9 @@ spring:
     hibernate:
       ddl-auto: none
     database-platform: org.hibernate.dialect.MariaDBDialect
-
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
   servlet:
     multipart:
       max-file-size: 50MB

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -11,6 +11,7 @@ import com.yapp.itemfinder.domain.member.Social
 import com.yapp.itemfinder.domain.member.SocialType
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import com.yapp.itemfinder.domain.space.SpaceEntity.Companion.SPACE_NAME_LENGTH_LIMIT
+import com.yapp.itemfinder.domain.tag.ItemTagEntity
 import com.yapp.itemfinder.domain.tag.TagEntity
 import java.util.UUID
 
@@ -82,6 +83,17 @@ object FakeEntity {
             id = id,
             member = member,
             name = name
+        )
+    }
+    fun createFakeItemTagEntity(
+        id: Long = generateRandomPositiveLongValue(),
+        item: ItemEntity = createFakeItemEntity(),
+        tag: TagEntity = createFakeTagEntity()
+    ): ItemTagEntity {
+        return ItemTagEntity(
+            id = id,
+            item = item,
+            tag = tag
         )
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/QuerydslTestConfig.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/QuerydslTestConfig.kt
@@ -5,7 +5,7 @@ import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.ItemRepository
 import com.yapp.itemfinder.domain.member.MemberRepository
 import com.yapp.itemfinder.domain.space.SpaceRepository
-import com.yapp.itemfinder.domain.support.PaginationHelper
+import com.yapp.itemfinder.support.PaginationHelper
 import com.yapp.itemfinder.domain.tag.ItemTagRepository
 import com.yapp.itemfinder.domain.tag.TagRepository
 import org.springframework.boot.test.context.TestConfiguration

--- a/src/test/kotlin/com/yapp/itemfinder/QuerydslTestConfig.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/QuerydslTestConfig.kt
@@ -1,6 +1,13 @@
 package com.yapp.itemfinder
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.item.ItemRepository
+import com.yapp.itemfinder.domain.member.MemberRepository
+import com.yapp.itemfinder.domain.space.SpaceRepository
+import com.yapp.itemfinder.domain.support.PaginationHelper
+import com.yapp.itemfinder.domain.tag.ItemTagRepository
+import com.yapp.itemfinder.domain.tag.TagRepository
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import javax.persistence.EntityManager
@@ -15,5 +22,27 @@ class QuerydslTestConfig {
     @Bean
     fun jpaQueryFactory(): JPAQueryFactory {
         return JPAQueryFactory(entityManager)
+    }
+    @Bean
+    fun paginationHelper(): PaginationHelper {
+        return PaginationHelper(entityManager)
+    }
+    @Bean
+    fun testCaseUtil(
+        itemRepository: ItemRepository,
+        memberRepository: MemberRepository,
+        containerRepository: ContainerRepository,
+        spaceRepository: SpaceRepository,
+        itemTagRepository: ItemTagRepository,
+        tagRepository: TagRepository
+    ): TestCaseUtil {
+        return TestCaseUtil(
+            itemRepository = itemRepository,
+            memberRepository = memberRepository,
+            containerRepository = containerRepository,
+            spaceRepository = spaceRepository,
+            itemTagRepository = itemTagRepository,
+            tagRepository = tagRepository
+        )
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/TestCaseUtil.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/TestCaseUtil.kt
@@ -1,0 +1,46 @@
+package com.yapp.itemfinder
+
+import com.yapp.itemfinder.domain.container.ContainerEntity
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.item.ItemEntity
+import com.yapp.itemfinder.domain.item.ItemRepository
+import com.yapp.itemfinder.domain.member.MemberEntity
+import com.yapp.itemfinder.domain.member.MemberRepository
+import com.yapp.itemfinder.domain.space.SpaceRepository
+import com.yapp.itemfinder.domain.tag.ItemTagRepository
+import com.yapp.itemfinder.domain.tag.TagRepository
+
+class TestCaseUtil(
+    private val itemRepository: ItemRepository,
+    private val memberRepository: MemberRepository,
+    private val containerRepository: ContainerRepository,
+    private val spaceRepository: SpaceRepository,
+    private val itemTagRepository: ItemTagRepository,
+    private val tagRepository: TagRepository
+) {
+    fun `한 명의 회원과 해당 회원이 저장한 하나의 아이템 반환`(): Pair<MemberEntity, ItemEntity> {
+        val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())
+        val givenSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
+        val givenContainer = containerRepository.save(FakeEntity.createFakeContainerEntity(space = givenSpace))
+        val givenItem = itemRepository.save(FakeEntity.createFakeItemEntity(container = givenContainer))
+        return givenMember to givenItem
+    }
+
+    fun `한 명의 회원과 해당 회원이 저장한 보관함 반환`(): Pair<MemberEntity, ContainerEntity> {
+        val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())
+        val givenSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = givenMember))
+        val givenContainer = containerRepository.save(FakeEntity.createFakeContainerEntity(space = givenSpace))
+        return givenMember to givenContainer
+    }
+
+    fun `한 개의 아이템에 전달받은 태그 이름들에 대한 태그 등록`(
+        item: ItemEntity,
+        tagNames: List<String>,
+        member: MemberEntity
+    ) {
+        tagNames.forEach {
+            val tag = tagRepository.save(FakeEntity.createFakeTagEntity(member = member, name = it))
+            itemTagRepository.save(FakeEntity.createFakeItemTagEntity(item = item, tag = tag))
+        }
+    }
+}

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -61,6 +61,15 @@ class ContainerRepositoryTest(
                 container.space.member.id shouldBe givenMember.id
             }
         }
+
+        When("회원 아이디를 전달받으면") {
+            val containers = containerRepository.findByMemberId(givenMember.id)
+
+            Then("회원이 등록한 공간 정보들을 반환한다") {
+                containers.size shouldBe 2
+                containers shouldBe givenContainers
+            }
+        }
     }
 
     Given("특정 공간에 여러 보관함이 저장되어 있을 때") {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -62,29 +62,31 @@ class ItemRepositoryTest(
         }
     }
 
-    Given("보관함에 2개의 태그를 설정한 아이템이 저장되어 있을 때") {
+    Given("2개의 태그가 설정된 아이템이 저장되어 있을 때") {
         val givenPageable = PageRequest.of(0, 20)
         val (givenMember, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
-        val (givenItemName, givenFirstTagName, givenSecondTagName) = Triple(generateRandomString(10), generateRandomString(10), generateRandomString(10))
 
+        val (givenItemName, givenFirstTagName, givenSecondTagName) = Triple(generateRandomString(10), generateRandomString(10), generateRandomString(10))
         val givenItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenItemName))
+
         testCaseUtil.`한 개의 아이템에 전달받은 태그 이름들에 대한 태그 등록`(item = givenItem, tagNames = listOf(givenFirstTagName, givenSecondTagName), member = givenMember)
 
         When("태그 이름에 대한 필터를 설정하고 조회한다면") {
-            val searchOptionWithSavedTags = SearchOption(tagNames = listOf(givenFirstTagName, givenSecondTagName))
-            val searchOptionWithUnsavedTags = SearchOption(tagNames = listOf(generateRandomString(10), givenFirstTagName, givenSecondTagName))
-            val searchResultWithSavedTags = itemRepository.search(searchOptionWithSavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
-            val searchResultWithUnsavedTags = itemRepository.search(searchOptionWithUnsavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchOptionContainSavedTags = SearchOption(tagNames = listOf(givenFirstTagName, givenSecondTagName))
+            val searchOptionContainUnsavedTags = SearchOption(tagNames = listOf(generateRandomString(10), givenFirstTagName, givenSecondTagName))
+
+            val searchResultContainSavedTags = itemRepository.search(searchOptionContainSavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchResultContainUnsavedTags = itemRepository.search(searchOptionContainUnsavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 태그를 모두 보유한 아이템만 조회된다") {
-                searchResultWithSavedTags.content.size shouldBe 1
-                searchResultWithSavedTags.totalElements shouldBe 1
-                searchResultWithSavedTags.totalPages shouldBe 1
-                searchResultWithSavedTags.content shouldContain givenItem
+                searchResultContainSavedTags.content.size shouldBe 1
+                searchResultContainSavedTags.totalElements shouldBe 1
+                searchResultContainSavedTags.totalPages shouldBe 1
+                searchResultContainSavedTags.content shouldContain givenItem
 
-                searchResultWithUnsavedTags.content.size shouldBe 0
-                searchResultWithUnsavedTags.totalElements shouldBe 0
-                searchResultWithUnsavedTags.totalPages shouldBe 0
+                searchResultContainUnsavedTags.content.size shouldBe 0
+                searchResultContainUnsavedTags.totalElements shouldBe 0
+                searchResultContainUnsavedTags.totalPages shouldBe 0
             }
         }
 
@@ -130,7 +132,7 @@ class ItemRepositoryTest(
         }
     }
 
-    Given("보관함에 2개의 아이템이 저장되어 있을 때") {
+    Given("2개의 이름이 설정된 아이템이 저장되어 있을 때") {
         val (_, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
         val (givenFirstItemName, givenSecondItemName) = "가나다" to "마바사"
         val givenFirstItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenFirstItemName)).also {
@@ -139,11 +141,8 @@ class ItemRepositoryTest(
         val givenSecondItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenSecondItemName))
 
         When("이름 오름차 순으로 조회한다면") {
-            val searchOption = SearchOption(
-                sortOrderOption = SortOrderOption.NameAsc
-            )
-            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
-            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchOption = SearchOption(sortOrderOption = SortOrderOption.NameAsc)
+            val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
                 result.content.size shouldBe 2
@@ -152,11 +151,8 @@ class ItemRepositoryTest(
         }
 
         When("이름 내림자 순으로 조회한다면") {
-            val searchOption = SearchOption(
-                sortOrderOption = SortOrderOption.NameDesc
-            )
-            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
-            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchOption = SearchOption(sortOrderOption = SortOrderOption.NameDesc)
+            val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
                 result.content.size shouldBe 2
@@ -165,11 +161,8 @@ class ItemRepositoryTest(
         }
 
         When("예전에 생성된 시간 순으로 조회한다면") {
-            val searchOption = SearchOption(
-                sortOrderOption = SortOrderOption.PastCreated
-            )
-            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
-            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchOption = SearchOption(sortOrderOption = SortOrderOption.PastCreated)
+            val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
                 result.content.size shouldBe 2
@@ -178,11 +171,8 @@ class ItemRepositoryTest(
         }
 
         When("최근에 생성된 시간 순으로 조회한다면") {
-            val searchOption = SearchOption(
-                sortOrderOption = SortOrderOption.RecentCreated
-            )
-            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
-            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchOption = SearchOption(sortOrderOption = SortOrderOption.RecentCreated)
+            val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
                 result.content.size shouldBe 2

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -5,7 +5,7 @@ import com.yapp.itemfinder.RepositoryTest
 import com.yapp.itemfinder.TestCaseUtil
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.TestUtil.generateRandomString
-import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.SortOrderOption
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContain
@@ -36,7 +36,7 @@ class ItemRepositoryTest(
         }
 
         When("아이템 타입 필터 조건 없이 페이징 데이터를 요청한다면") {
-            val searchOption = SearchOption(
+            val searchOption = ItemSearchOption(
                 itemTypes = emptyList()
             )
             val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
@@ -49,7 +49,7 @@ class ItemRepositoryTest(
         }
 
         When("아이템 타입 필터 조건을 포함해서 페이징 데이터를 요청한다면") {
-            val searchOption = SearchOption(
+            val searchOption = ItemSearchOption(
                 itemTypes = listOf(ItemType.FASHION, ItemType.LIFE)
             )
             val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
@@ -72,8 +72,8 @@ class ItemRepositoryTest(
         testCaseUtil.`한 개의 아이템에 전달받은 태그 이름들에 대한 태그 등록`(item = givenItem, tagNames = listOf(givenFirstTagName, givenSecondTagName), member = givenMember)
 
         When("태그 이름에 대한 필터를 설정하고 조회한다면") {
-            val searchOptionContainSavedTags = SearchOption(tagNames = listOf(givenFirstTagName, givenSecondTagName))
-            val searchOptionContainUnsavedTags = SearchOption(tagNames = listOf(generateRandomString(10), givenFirstTagName, givenSecondTagName))
+            val searchOptionContainSavedTags = ItemSearchOption(tagNames = listOf(givenFirstTagName, givenSecondTagName))
+            val searchOptionContainUnsavedTags = ItemSearchOption(tagNames = listOf(generateRandomString(10), givenFirstTagName, givenSecondTagName))
 
             val searchResultContainSavedTags = itemRepository.search(searchOptionContainSavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
             val searchResultContainUnsavedTags = itemRepository.search(searchOptionContainUnsavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
@@ -91,7 +91,7 @@ class ItemRepositoryTest(
         }
 
         When("아이템 이름에 대한 필터를 설정했을 때 해당 이름을 포함하고 있는 아이템이 존재한다면") {
-            val searchOption = SearchOption(
+            val searchOption = ItemSearchOption(
                 tagNames = listOf(givenFirstTagName, givenSecondTagName),
                 itemName = givenItemName.substring(2 until 5)
             )
@@ -107,7 +107,7 @@ class ItemRepositoryTest(
         }
 
         When("아이템 이름에 대한 필터를 설정했을 때 해당 이름을 포함하고 있는 아이템이 존재하지 않는다면") {
-            val searchOption = SearchOption(
+            val searchOption = ItemSearchOption(
                 itemName = givenItemName.substring(2 until 5).plus(generateRandomString(20))
             )
             val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
@@ -121,7 +121,7 @@ class ItemRepositoryTest(
 
         When("아이템이 존재하지 않는 보관함에 대한 아이디로 조회한다면") {
             val result = itemRepository.search(
-                SearchOption(), givenPageable, targetContainerIds = listOf(generateRandomPositiveLongValue())
+                ItemSearchOption(), givenPageable, targetContainerIds = listOf(generateRandomPositiveLongValue())
             )
 
             Then("해당 아이템이 조회되지 않는다") {
@@ -141,7 +141,7 @@ class ItemRepositoryTest(
         val givenSecondItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenSecondItemName))
 
         When("이름 오름차 순으로 조회한다면") {
-            val searchOption = SearchOption(sortOrderOption = SortOrderOption.NameAsc)
+            val searchOption = ItemSearchOption(sortOrderOption = SortOrderOption.NameAsc)
             val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
@@ -151,7 +151,7 @@ class ItemRepositoryTest(
         }
 
         When("이름 내림자 순으로 조회한다면") {
-            val searchOption = SearchOption(sortOrderOption = SortOrderOption.NameDesc)
+            val searchOption = ItemSearchOption(sortOrderOption = SortOrderOption.NameDesc)
             val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
@@ -161,7 +161,7 @@ class ItemRepositoryTest(
         }
 
         When("예전에 생성된 시간 순으로 조회한다면") {
-            val searchOption = SearchOption(sortOrderOption = SortOrderOption.PastCreated)
+            val searchOption = ItemSearchOption(sortOrderOption = SortOrderOption.PastCreated)
             val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {
@@ -171,7 +171,7 @@ class ItemRepositoryTest(
         }
 
         When("최근에 생성된 시간 순으로 조회한다면") {
-            val searchOption = SearchOption(sortOrderOption = SortOrderOption.RecentCreated)
+            val searchOption = ItemSearchOption(sortOrderOption = SortOrderOption.RecentCreated)
             val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 
             Then("해당 순서대로 정렬해서 반환한다") {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -1,0 +1,193 @@
+package com.yapp.itemfinder.domain.item
+
+import com.yapp.itemfinder.FakeEntity.createFakeItemEntity
+import com.yapp.itemfinder.RepositoryTest
+import com.yapp.itemfinder.TestCaseUtil
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
+import com.yapp.itemfinder.TestUtil.generateRandomString
+import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.SortOrderOption
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+
+@RepositoryTest
+class ItemRepositoryTest(
+    private val itemRepository: ItemRepository,
+    private val testCaseUtil: TestCaseUtil
+) : BehaviorSpec({
+
+    Given("21개의 아이템이 10개는 패션으로, 5개는 라이프스타일로, 6개는 음식으로 등록되었다면") {
+        val (fashionItemCount, lifeItemCount, foodItemCount) = Triple(10, 5, 6)
+        val givenPageable = PageRequest.of(0, 20)
+        val (_, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
+
+        repeat(fashionItemCount) {
+            itemRepository.save(createFakeItemEntity(container = givenContainer, type = ItemType.FASHION))
+        }
+        repeat(lifeItemCount) {
+            itemRepository.save(createFakeItemEntity(container = givenContainer, type = ItemType.LIFE))
+        }
+        repeat(foodItemCount) {
+            itemRepository.save(createFakeItemEntity(container = givenContainer, type = ItemType.FOOD))
+        }
+
+        When("아이템 타입 필터 조건 없이 페이징 데이터를 요청한다면") {
+            val searchOption = SearchOption(
+                itemTypes = emptyList()
+            )
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("카테고리 필터 없이 페이지 수만큼 페이징을 진행해서 결과를 반환한다") {
+                result.content.size shouldBe givenPageable.pageSize
+                result.totalElements shouldBe fashionItemCount + lifeItemCount + foodItemCount
+                result.totalPages shouldBe 2
+            }
+        }
+
+        When("아이템 타입 필터 조건을 포함해서 페이징 데이터를 요청한다면") {
+            val searchOption = SearchOption(
+                itemTypes = listOf(ItemType.FASHION, ItemType.LIFE)
+            )
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("전달받은 아이템 타입에 해당하는 아이템만 조회한다") {
+                result.content.size shouldBe fashionItemCount + lifeItemCount
+                result.totalElements shouldBe fashionItemCount + lifeItemCount
+                result.totalPages shouldBe 1
+            }
+        }
+    }
+
+    Given("보관함에 2개의 태그를 설정한 아이템이 저장되어 있을 때") {
+        val givenPageable = PageRequest.of(0, 20)
+        val (givenMember, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
+        val (givenItemName, givenFirstTagName, givenSecondTagName) = Triple(generateRandomString(10), generateRandomString(10), generateRandomString(10))
+
+        val givenItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenItemName))
+        testCaseUtil.`한 개의 아이템에 전달받은 태그 이름들에 대한 태그 등록`(item = givenItem, tagNames = listOf(givenFirstTagName, givenSecondTagName), member = givenMember)
+
+        When("태그 이름에 대한 필터를 설정하고 조회한다면") {
+            val searchOptionWithSavedTags = SearchOption(tagNames = listOf(givenFirstTagName, givenSecondTagName))
+            val searchOptionWithUnsavedTags = SearchOption(tagNames = listOf(generateRandomString(10), givenFirstTagName, givenSecondTagName))
+            val searchResultWithSavedTags = itemRepository.search(searchOptionWithSavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
+            val searchResultWithUnsavedTags = itemRepository.search(searchOptionWithUnsavedTags, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 태그를 모두 보유한 아이템만 조회된다") {
+                searchResultWithSavedTags.content.size shouldBe 1
+                searchResultWithSavedTags.totalElements shouldBe 1
+                searchResultWithSavedTags.totalPages shouldBe 1
+                searchResultWithSavedTags.content shouldContain givenItem
+
+                searchResultWithUnsavedTags.content.size shouldBe 0
+                searchResultWithUnsavedTags.totalElements shouldBe 0
+                searchResultWithUnsavedTags.totalPages shouldBe 0
+            }
+        }
+
+        When("아이템 이름에 대한 필터를 설정했을 때 해당 이름을 포함하고 있는 아이템이 존재한다면") {
+            val searchOption = SearchOption(
+                tagNames = listOf(givenFirstTagName, givenSecondTagName),
+                itemName = givenItemName.substring(2 until 5)
+            )
+
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 아이템이 조회된다") {
+                result.content shouldContain givenItem
+                result.content.size shouldBe 1
+                result.totalElements shouldBe 1
+                result.totalPages shouldBe 1
+            }
+        }
+
+        When("아이템 이름에 대한 필터를 설정했을 때 해당 이름을 포함하고 있는 아이템이 존재하지 않는다면") {
+            val searchOption = SearchOption(
+                itemName = givenItemName.substring(2 until 5).plus(generateRandomString(20))
+            )
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("어떤 아이템도 조회되지 않는다") {
+                result.content.size shouldBe 0
+                result.totalElements shouldBe 0
+                result.totalPages shouldBe 0
+            }
+        }
+
+        When("아이템이 존재하지 않는 보관함에 대한 아이디로 조회한다면") {
+            val result = itemRepository.search(
+                SearchOption(), givenPageable, targetContainerIds = listOf(generateRandomPositiveLongValue())
+            )
+
+            Then("해당 아이템이 조회되지 않는다") {
+                result.content.size shouldBe 0
+                result.totalElements shouldBe 0
+                result.totalPages shouldBe 0
+            }
+        }
+    }
+
+    Given("보관함에 2개의 아이템이 저장되어 있을 때") {
+        val (_, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
+        val (givenFirstItemName, givenSecondItemName) = "가나다" to "마바사"
+        val givenFirstItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenFirstItemName)).also {
+            it.createdAt = LocalDateTime.now().minusDays(1)
+        }
+        val givenSecondItem = itemRepository.save(createFakeItemEntity(container = givenContainer, name = givenSecondItemName))
+
+        When("이름 오름차 순으로 조회한다면") {
+            val searchOption = SearchOption(
+                sortOrderOption = SortOrderOption.NameAsc
+            )
+            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 순서대로 정렬해서 반환한다") {
+                result.content.size shouldBe 2
+                result.content shouldContainInOrder listOf(givenFirstItem, givenSecondItem)
+            }
+        }
+
+        When("이름 내림자 순으로 조회한다면") {
+            val searchOption = SearchOption(
+                sortOrderOption = SortOrderOption.NameDesc
+            )
+            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 순서대로 정렬해서 반환한다") {
+                result.content.size shouldBe 2
+                result.content shouldContainInOrder listOf(givenSecondItem, givenFirstItem)
+            }
+        }
+
+        When("예전에 생성된 시간 순으로 조회한다면") {
+            val searchOption = SearchOption(
+                sortOrderOption = SortOrderOption.PastCreated
+            )
+            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 순서대로 정렬해서 반환한다") {
+                result.content.size shouldBe 2
+                result.content shouldContainInOrder listOf(givenFirstItem, givenSecondItem)
+            }
+        }
+
+        When("최근에 생성된 시간 순으로 조회한다면") {
+            val searchOption = SearchOption(
+                sortOrderOption = SortOrderOption.RecentCreated
+            )
+            val givenPageable = PageRequest.of(0, 20, searchOption.getSort())
+            val result = itemRepository.search(searchOption, givenPageable, targetContainerIds = listOf(givenContainer.id))
+
+            Then("해당 순서대로 정렬해서 반환한다") {
+                result.content.size shouldBe 2
+                result.content shouldContainInOrder listOf(givenSecondItem, givenFirstItem)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -6,7 +6,7 @@ import com.yapp.itemfinder.TestCaseUtil
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.TestUtil.generateRandomString
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
-import com.yapp.itemfinder.domain.item.dto.SortOrderOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SortOrderOption
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainInOrder

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -179,5 +179,16 @@ class ItemRepositoryTest(
                 result.content shouldContainInOrder listOf(givenSecondItem, givenFirstItem)
             }
         }
+
+        When("찾을 대상으로 전달받은 보관함 아이디가 없다면") {
+            val emptyContainers = emptyList<Long>()
+
+            val result = itemRepository.search(ItemSearchOption(), PageRequest.of(0, 20), emptyContainers)
+
+            Then("아이템이 조회되지 않는다") {
+                result.content.size shouldBe 0
+                result.content shouldBe emptyList()
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -150,7 +150,7 @@ class ItemRepositoryTest(
             }
         }
 
-        When("이름 내림자 순으로 조회한다면") {
+        When("이름 내림차 순으로 조회한다면") {
             val searchOption = ItemSearchOption(sortOrderOption = SortOrderOption.NameDesc)
             val result = itemRepository.search(searchOption, PageRequest.of(0, 20, searchOption.getSort()), targetContainerIds = listOf(givenContainer.id))
 

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -11,7 +11,7 @@ import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.SearchOption
 import com.yapp.itemfinder.domain.item.dto.SearchTarget
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation
-import com.yapp.itemfinder.domain.item.service.PermissionValidator
+import com.yapp.itemfinder.support.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -120,6 +120,30 @@ class ItemServiceTest : BehaviorSpec({
             }
         }
 
+        When("공간/보관함 등 특정 위치을 대상으로 아이템 검색을 진행하지 않았다면") {
+            val givenSearchOption = ItemSearchOption()
+            val givenContainerIdsOfMember = listOf(1L, 2L)
+            val givenContainersOfMember = listOf(
+                createFakeContainerEntity(id = givenContainerIdsOfMember.first(), space = givenSpace),
+                createFakeContainerEntity(id = givenContainerIdsOfMember.last(), space = givenSpace),
+            )
+
+            every { containerRepository.findByMemberId(givenMemberId) } returns givenContainersOfMember
+
+            itemService.search(givenSearchOption, givenPageRequest, givenMemberId)
+
+            Then("해당 회원이 등록한 모든 보관함에 등록된 아이템을 대상으로 조회한다") {
+                verify(exactly = 1) {
+                    itemRepository.search(
+                        givenSearchOption,
+                        givenPageRequest,
+                        capture(searchTargetContainerIds)
+                    )
+                }
+                searchTargetContainerIds.captured shouldBe givenContainerIdsOfMember
+            }
+        }
+
         When("검색을 통해 태그가 5개 등록된 아이템이 조회된 경우") {
             val givenSearchOption = ItemSearchOption(
                 searchTarget = SearchTarget(location = SearchLocation.CONTAINER, id = givenContainerId)

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -9,8 +9,8 @@ import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
-import com.yapp.itemfinder.domain.item.dto.SearchTarget
-import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget.SearchLocation
 import com.yapp.itemfinder.support.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
 import io.kotest.assertions.assertSoftly

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -8,7 +8,7 @@ import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
-import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.SearchTarget
 import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation
 import com.yapp.itemfinder.support.PermissionValidator
@@ -72,7 +72,7 @@ class ItemServiceTest : BehaviorSpec({
 
         When("공간을 대상으로 해당 공간에 등록된 아이템에 대한 검색을 진행했다면") {
             val (givenFirstContainerIdInSpace, givenSecondContainerIdInSpace) = generateRandomPositiveLongValue() to generateRandomPositiveLongValue()
-            val givenSearchOption = SearchOption(
+            val givenSearchOption = ItemSearchOption(
                 searchTarget = SearchTarget(location = SearchLocation.SPACE, id = givenSpaceId)
             )
 
@@ -100,7 +100,7 @@ class ItemServiceTest : BehaviorSpec({
         }
 
         When("보관함을 대상으로 해당 보관함에 등록된 아이템에 대한 검색을 진행했다면") {
-            val givenSearchOption = SearchOption(
+            val givenSearchOption = ItemSearchOption(
                 searchTarget = SearchTarget(location = SearchLocation.CONTAINER, id = givenContainerId)
             )
 
@@ -121,7 +121,7 @@ class ItemServiceTest : BehaviorSpec({
         }
 
         When("검색을 통해 태그가 5개 등록된 아이템이 조회된 경우") {
-            val givenSearchOption = SearchOption(
+            val givenSearchOption = ItemSearchOption(
                 searchTarget = SearchTarget(location = SearchLocation.CONTAINER, id = givenContainerId)
             )
             val givenItemId = generateRandomPositiveLongValue()

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -77,7 +77,7 @@ class ItemServiceTest : BehaviorSpec({
             )
 
             every { permissionValidator.validateSpaceByMemberId(givenMemberId, givenSpaceId) } returns givenSpace
-            every { containerRepository.findBySpaceOrderByCreatedAtAsc(givenSpace) } returns listOf(
+            every { containerRepository.findBySpace(givenSpace) } returns listOf(
                 createFakeContainerEntity(id = givenFirstContainerIdInSpace, space = givenSpace),
                 createFakeContainerEntity(id = givenSecondContainerIdInSpace, space = givenSpace)
             )

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemServiceTest.kt
@@ -1,26 +1,40 @@
 package com.yapp.itemfinder.domain.item
 
 import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeItemEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
+import com.yapp.itemfinder.domain.item.dto.SearchOption
+import com.yapp.itemfinder.domain.item.dto.SearchTarget
+import com.yapp.itemfinder.domain.item.dto.SearchTarget.SearchLocation
+import com.yapp.itemfinder.domain.item.service.PermissionValidator
 import com.yapp.itemfinder.domain.tag.ItemTagService
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 
 class ItemServiceTest : BehaviorSpec({
-    val itemRepository = mockk<ItemRepository>()
-    val containerRepository = mockk<ContainerRepository>()
-    val itemTagService = mockk<ItemTagService>()
-    val itemService = ItemService(itemRepository, containerRepository, itemTagService)
+    val itemRepository = mockk<ItemRepository>(relaxed = true)
+    val containerRepository = mockk<ContainerRepository>(relaxed = true)
+    val itemTagService = mockk<ItemTagService>(relaxed = true)
+    val permissionValidator = mockk<PermissionValidator>(relaxed = true)
+    val itemService = ItemService(itemRepository, containerRepository, itemTagService, permissionValidator)
 
     Given("이미지가 없는 보관함이 등록된 경우") {
         val givenMember = FakeEntity.createFakeMemberEntity()
-        val givenSpace = FakeEntity.createFakeSpaceEntity(member = givenMember)
-        val givenContainer = FakeEntity.createFakeContainerEntity(space = givenSpace, imageUrl = null)
+        val givenSpace = createFakeSpaceEntity(member = givenMember)
+        val givenContainer = createFakeContainerEntity(space = givenSpace, imageUrl = null)
 
         every { containerRepository.findWithSpaceByIdAndMemberId(givenContainer.id, givenMember.id) } returns givenContainer
         every { itemRepository.save(any()) } answers { firstArg() }
@@ -45,6 +59,94 @@ class ItemServiceTest : BehaviorSpec({
                 shouldThrow<BadRequestException> {
                     itemService.createItem(request, givenMember.id)
                 }.message
+            }
+        }
+    }
+
+    Given("멤버가 물건들을 조회할 때") {
+        val (givenSpaceId, givenContainerId, givenMemberId) = Triple(generateRandomPositiveLongValue(), generateRandomPositiveLongValue(), generateRandomPositiveLongValue())
+        val givenSpace = createFakeSpaceEntity(id = givenSpaceId)
+        val givenContainer = createFakeContainerEntity(space = givenSpace, id = givenContainerId)
+        val givenPageRequest = PageRequest.of(0, 20)
+        val searchTargetContainerIds = slot<List<Long>>()
+
+        When("공간을 대상으로 해당 공간에 등록된 아이템에 대한 검색을 진행했다면") {
+            val (givenFirstContainerIdInSpace, givenSecondContainerIdInSpace) = generateRandomPositiveLongValue() to generateRandomPositiveLongValue()
+            val givenSearchOption = SearchOption(
+                searchTarget = SearchTarget(location = SearchLocation.SPACE, id = givenSpaceId)
+            )
+
+            every { permissionValidator.validateSpaceByMemberId(givenMemberId, givenSpaceId) } returns givenSpace
+            every { containerRepository.findBySpaceOrderByCreatedAtAsc(givenSpace) } returns listOf(
+                createFakeContainerEntity(id = givenFirstContainerIdInSpace, space = givenSpace),
+                createFakeContainerEntity(id = givenSecondContainerIdInSpace, space = givenSpace)
+            )
+
+            itemService.search(givenSearchOption, givenPageRequest, givenMemberId)
+
+            Then("해당 공간에 대한 유저의 권한을 확인한 후, 해당 공간에 속한 보관함 아이디를 찾아 해당 보관함을 대상으로 아이템을 검색한다") {
+                verify(exactly = 1) {
+                    itemRepository.search(
+                        givenSearchOption,
+                        givenPageRequest,
+                        capture(searchTargetContainerIds)
+                    )
+                }
+                verify(exactly = 1) {
+                    permissionValidator.validateSpaceByMemberId(givenMemberId, givenSpaceId)
+                }
+                searchTargetContainerIds.captured shouldBe listOf(givenFirstContainerIdInSpace, givenSecondContainerIdInSpace)
+            }
+        }
+
+        When("보관함을 대상으로 해당 보관함에 등록된 아이템에 대한 검색을 진행했다면") {
+            val givenSearchOption = SearchOption(
+                searchTarget = SearchTarget(location = SearchLocation.CONTAINER, id = givenContainerId)
+            )
+
+            every { permissionValidator.validateContainerByMemberId(givenMemberId, givenContainerId) } returns givenContainer
+
+            itemService.search(givenSearchOption, givenPageRequest, givenMemberId)
+
+            Then("해당 보관함에 대한 유저의 권한을 확인한 후, 해당 보관함 아이디를 대상으로 아이템을 검색한다") {
+                verify(exactly = 1) {
+                    itemRepository.search(
+                        givenSearchOption,
+                        givenPageRequest,
+                        capture(searchTargetContainerIds)
+                    )
+                }
+                searchTargetContainerIds.captured shouldBe listOf(givenContainerId)
+            }
+        }
+
+        When("검색을 통해 태그가 5개 등록된 아이템이 조회된 경우") {
+            val givenSearchOption = SearchOption(
+                searchTarget = SearchTarget(location = SearchLocation.CONTAINER, id = givenContainerId)
+            )
+            val givenItemId = generateRandomPositiveLongValue()
+            val givenItem = createFakeItemEntity(id = givenItemId, container = givenContainer)
+
+            every { permissionValidator.validateContainerByMemberId(givenMemberId, givenContainerId) } returns givenContainer
+            every { itemRepository.search(givenSearchOption, givenPageRequest, listOf(givenContainerId)) } returns
+                PageImpl(listOf(givenItem), givenPageRequest, 1)
+
+            And("찾은 아이템을 대상으로 해당 아이템들의 태그를 찾고") {
+                val givenTagNames = listOf("태그1", "태그2", "태그3", "태그4", "태그5")
+                every { itemTagService.createItemIdToTagNames(itemIds = listOf(givenItemId)) } returns mapOf(givenItemId to givenTagNames)
+
+                Then("찾은 대그에 대해 아이템 당 최대 4개의 태그까지만 아이템 결과에 담아서 반환한다") {
+                    val response = itemService.search(givenSearchOption, givenPageRequest, givenMemberId)
+                    assertSoftly {
+                        response.totalCount shouldBe 1
+                        with(response.data.first()) {
+                            tags.size shouldBe 4
+                            tags shouldBe givenTagNames.subList(0, 4)
+                            name shouldBe givenItem.name
+                            id shouldBe givenItemId
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
@@ -26,7 +26,7 @@ class PermissionValidatorTest : BehaviorSpec({
         val givenSpace = createFakeSpaceEntity(member = givenMember)
         val (givenMemberId, givenSpaceId) = givenMember.id to givenSpace.id
 
-        When("등록하지 않은 공간으로 유저가 헤딩 공간에 대한 권한을 검즐한다면") {
+        When("등록하지 않은 공간으로 유저가 해당 공간에 대한 권한을 검증한다면") {
             val givenNonExistSpaceId = generateRandomPositiveLongValue()
             every { spaceRepository.findByIdOrNull(givenNonExistSpaceId) } returns null
 

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
@@ -8,6 +8,7 @@ import com.yapp.itemfinder.api.exception.ForbiddenException
 import com.yapp.itemfinder.api.exception.NotFoundException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.space.SpaceRepository
+import com.yapp.itemfinder.support.PermissionValidator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
@@ -1,0 +1,118 @@
+package com.yapp.itemfinder.domain.item.service
+
+import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
+import com.yapp.itemfinder.api.exception.ForbiddenException
+import com.yapp.itemfinder.api.exception.NotFoundException
+import com.yapp.itemfinder.domain.container.ContainerRepository
+import com.yapp.itemfinder.domain.space.SpaceRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.repository.findByIdOrNull
+
+class PermissionValidatorTest : BehaviorSpec({
+    val containerRepository = mockk<ContainerRepository>()
+    val spaceRepository = mockk<SpaceRepository>()
+    val permissionValidator = PermissionValidator(containerRepository, spaceRepository)
+
+    Given("멤버가 한 공간을 등록한 경우") {
+        val givenMember = createFakeMemberEntity()
+        val givenSpace = createFakeSpaceEntity(member = givenMember)
+        val (givenMemberId, givenSpaceId) = givenMember.id to givenSpace.id
+
+        When("존재하지 않은 공간으로 유저가 등록했는지에 대해 요청한 경우") {
+            val givenNonExistSpaceId = generateRandomPositiveLongValue()
+            every { spaceRepository.findByIdOrNull(givenNonExistSpaceId) } returns null
+
+            Then("예외가 발생한다") {
+                shouldThrow<NotFoundException> {
+                    permissionValidator.validateSpaceByMemberId(
+                        memberId = givenMemberId,
+                        spaceId = givenNonExistSpaceId
+                    )
+                }
+            }
+        }
+
+        When("해당 공간이 존재하지만 요청한 유저가 등록한 공간이 아니라면") {
+            every { spaceRepository.findByIdOrNull(givenSpaceId) } returns givenSpace
+
+            val givenAnotherMemberId = generateRandomPositiveLongValue()
+
+            Then("예외가 발생한다") {
+                shouldThrow<ForbiddenException> {
+                    permissionValidator.validateSpaceByMemberId(
+                        memberId = givenAnotherMemberId,
+                        spaceId = givenSpaceId
+                    )
+                }
+            }
+        }
+
+        When("해당 공간이 존재하고, 요청한 유저가 등록한 공간이라면") {
+            every { spaceRepository.findByIdOrNull(givenSpaceId) } returns givenSpace
+
+            val result = permissionValidator.validateSpaceByMemberId(
+                memberId = givenMemberId,
+                spaceId = givenSpaceId
+            )
+
+            Then("검증을 통과한 공간을 반환한다") {
+                result shouldBe givenSpace
+            }
+        }
+    }
+
+    Given("멤버가 한 보관함을 등록한 경우") {
+        val givenMember = createFakeMemberEntity()
+        val givenContainer = createFakeContainerEntity(space = createFakeSpaceEntity(member = givenMember))
+        val (givenMemberId, givenContainerId) = givenMember.id to givenContainer.id
+
+        When("존재하지 않은 보관함으로 유저가 등록했는지에 대해 요청한 경우") {
+            val givenNonExistContainerId = generateRandomPositiveLongValue()
+            every { containerRepository.findByIdWithSpace(givenNonExistContainerId) } returns null
+
+            Then("예외가 발생한다") {
+                shouldThrow<NotFoundException> {
+                    permissionValidator.validateContainerByMemberId(
+                        memberId = givenMemberId,
+                        containerId = givenNonExistContainerId
+                    )
+                }
+            }
+        }
+
+        When("해당 보관함이 존재하지만 요청한 유저가 등록한 보관함이 아니라면") {
+            every { containerRepository.findByIdWithSpace(givenContainerId) } returns givenContainer
+
+            val givenAnotherMemberId = generateRandomPositiveLongValue()
+
+            Then("예외가 발생한다") {
+                shouldThrow<ForbiddenException> {
+                    permissionValidator.validateContainerByMemberId(
+                        memberId = givenAnotherMemberId,
+                        containerId = givenContainerId
+                    )
+                }
+            }
+        }
+
+        When("해당 보관함이 존재하고, 요청한 유저가 등록한 보관함이라면") {
+            every { containerRepository.findByIdWithSpace(givenContainerId) } returns givenContainer
+
+            val result = permissionValidator.validateContainerByMemberId(
+                memberId = givenMemberId,
+                containerId = givenContainerId
+            )
+
+            Then("검증을 통과한 보관함을 반환한다") {
+                result shouldBe givenContainer
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/service/PermissionValidatorTest.kt
@@ -25,7 +25,7 @@ class PermissionValidatorTest : BehaviorSpec({
         val givenSpace = createFakeSpaceEntity(member = givenMember)
         val (givenMemberId, givenSpaceId) = givenMember.id to givenSpace.id
 
-        When("존재하지 않은 공간으로 유저가 등록했는지에 대해 요청한 경우") {
+        When("등록하지 않은 공간으로 유저가 헤딩 공간에 대한 권한을 검즐한다면") {
             val givenNonExistSpaceId = generateRandomPositiveLongValue()
             every { spaceRepository.findByIdOrNull(givenNonExistSpaceId) } returns null
 
@@ -39,7 +39,7 @@ class PermissionValidatorTest : BehaviorSpec({
             }
         }
 
-        When("해당 공간이 존재하지만 요청한 유저가 등록한 공간이 아니라면") {
+        When("존재하는 공간이지만 요청한 유저가 등록한 공간이 아닌 상황에서 권한을 검즐한다면") {
             every { spaceRepository.findByIdOrNull(givenSpaceId) } returns givenSpace
 
             val givenAnotherMemberId = generateRandomPositiveLongValue()
@@ -54,7 +54,7 @@ class PermissionValidatorTest : BehaviorSpec({
             }
         }
 
-        When("해당 공간이 존재하고, 요청한 유저가 등록한 공간이라면") {
+        When("해당 공간이 존재하고, 요청한 유저가 등록한 공간인 상황에서 권한을 검증한다면") {
             every { spaceRepository.findByIdOrNull(givenSpaceId) } returns givenSpace
 
             val result = permissionValidator.validateSpaceByMemberId(
@@ -62,7 +62,7 @@ class PermissionValidatorTest : BehaviorSpec({
                 spaceId = givenSpaceId
             )
 
-            Then("검증을 통과한 공간을 반환한다") {
+            Then("검증을 통과한 해당 공간을 반환한다") {
                 result shouldBe givenSpace
             }
         }
@@ -73,7 +73,7 @@ class PermissionValidatorTest : BehaviorSpec({
         val givenContainer = createFakeContainerEntity(space = createFakeSpaceEntity(member = givenMember))
         val (givenMemberId, givenContainerId) = givenMember.id to givenContainer.id
 
-        When("존재하지 않은 보관함으로 유저가 등록했는지에 대해 요청한 경우") {
+        When("존재하지 않은 보관함으로 유저가 등록했는지에 대해 권한을 검증한 경우") {
             val givenNonExistContainerId = generateRandomPositiveLongValue()
             every { containerRepository.findByIdWithSpace(givenNonExistContainerId) } returns null
 

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
@@ -69,10 +69,12 @@ class ItemTagRepositoryTest(
             listOf(createFakeTagEntity(name = "first", member = givenMember), createFakeTagEntity(name = "second", member = givenMember))
         )
 
-        itemTagRepository.saveAll(listOf(
-            FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenFirstTag),
-            FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenSecondTag),
-        ))
+        itemTagRepository.saveAll(
+            listOf(
+                FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenFirstTag),
+                FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenSecondTag)
+            )
+        )
 
         When("회원이 등록한 아이템 아이디 리스트로 태그 정보(item id, tag, name) 조회한다면") {
             val itemTagNames = itemTagRepository.findItemTagNameItemIdIsIn(itemIds = listOf(givenItem.id))

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
@@ -1,17 +1,20 @@
 package com.yapp.itemfinder.domain.tag
 
+import com.yapp.itemfinder.FakeEntity
 import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
 import com.yapp.itemfinder.FakeEntity.createFakeItemEntity
 import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
 import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.FakeEntity.createFakeTagEntity
 import com.yapp.itemfinder.RepositoryTest
+import com.yapp.itemfinder.TestCaseUtil
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.ItemRepository
 import com.yapp.itemfinder.domain.item.ItemType
 import com.yapp.itemfinder.domain.member.MemberRepository
 import com.yapp.itemfinder.domain.space.SpaceRepository
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
 @RepositoryTest
@@ -21,7 +24,8 @@ class ItemTagRepositoryTest(
     private val containerRepository: ContainerRepository,
     private val itemTagRepository: ItemTagRepository,
     private val itemRepository: ItemRepository,
-    private val tagRepository: TagRepository
+    private val tagRepository: TagRepository,
+    private val testCase: TestCaseUtil
 ) : BehaviorSpec({
 
     Given("회원이 아이템에 태그를 등록한 경우") {
@@ -54,6 +58,31 @@ class ItemTagRepositoryTest(
                         ItemType.FOOD.name -> dto.count shouldBe foodCnt
                     }
                 }
+            }
+        }
+    }
+
+    Given("회원이 아이템에 여러 태그를 등록한 경우") {
+        val (givenMember, givenItem) = testCase.`한 명의 회원과 해당 회원이 저장한 하나의 아이템 반환`()
+
+        val (givenFirstTag, givenSecondTag) = tagRepository.saveAll(
+            listOf(createFakeTagEntity(name = "first", member = givenMember), createFakeTagEntity(name = "second", member = givenMember))
+        )
+
+        itemTagRepository.saveAll(listOf(
+            FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenFirstTag),
+            FakeEntity.createFakeItemTagEntity(item = givenItem, tag = givenSecondTag),
+        ))
+
+        When("회원이 등록한 아이템 아이디 리스트로 태그 정보(item id, tag, name) 조회한다면") {
+            val itemTagNames = itemTagRepository.findItemTagNameItemIdIsIn(itemIds = listOf(givenItem.id))
+
+            Then("관련 태그 정보가 모두 조회된다") {
+                itemTagNames.size shouldBe 2
+                itemTagNames shouldContainExactlyInAnyOrder listOf(
+                    ItemIdWithTagName(itemId = givenItem.id, tagName = givenFirstTag.name),
+                    ItemIdWithTagName(itemId = givenItem.id, tagName = givenSecondTag.name),
+                )
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepositoryTest.kt
@@ -77,7 +77,7 @@ class ItemTagRepositoryTest(
         )
 
         When("회원이 등록한 아이템 아이디 리스트로 태그 정보(item id, tag, name) 조회한다면") {
-            val itemTagNames = itemTagRepository.findItemTagNameItemIdIsIn(itemIds = listOf(givenItem.id))
+            val itemTagNames = itemTagRepository.findItemIdAndTagNameByItemIdIsIn(itemIds = listOf(givenItem.id))
 
             Then("관련 태그 정보가 모두 조회된다") {
                 itemTagNames.size shouldBe 2

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
@@ -63,7 +63,7 @@ class ItemTagServiceTest : BehaviorSpec({
             ItemIdWithTagName(itemId = givenItemIds[0], givenTagNames[1]),
         )
 
-        every { itemTagRepository.findItemTagNameItemIdIsIn(givenItemIds) } returns givenItemIdWithTagNames
+        every { itemTagRepository.findItemIdAndTagNameByItemIdIsIn(givenItemIds) } returns givenItemIdWithTagNames
 
         When("아이템 아이디 리스트로 해당 아이디에 속한 태그 이름을 조회하면") {
             val itemIdToTagNames = itemTagService.createItemIdToTagNames(itemIds = givenItemIds)
@@ -80,7 +80,7 @@ class ItemTagServiceTest : BehaviorSpec({
 
             Then("실제로 태그를 조회하지 않고 빈 map을 반환한다") {
                 verify(exactly = 0) {
-                    itemTagRepository.findItemTagNameItemIdIsIn(any())
+                    itemTagRepository.findItemIdAndTagNameByItemIdIsIn(any())
                 }
                 result shouldBe emptyMap()
             }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
@@ -1,6 +1,7 @@
 package com.yapp.itemfinder.domain.tag
 
 import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.api.exception.BadRequestException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -49,6 +50,26 @@ class ItemTagServiceTest : BehaviorSpec({
                 shouldThrow<BadRequestException> {
                     itemTagService.createItemTags(item, givenTags.map { it.id }, givenMember.id)
                 }
+            }
+        }
+    }
+
+    Given("특정 아이템에 등록된 태그들이 존재하는 경우") {
+        val givenTagNames = listOf("tag1", "tag2")
+        val givenItemIds = listOf(generateRandomPositiveLongValue())
+        val givenItemIdWithTagNames: List<ItemIdWithTagName> = listOf(
+            ItemIdWithTagName(itemId = givenItemIds[0], givenTagNames[0]),
+            ItemIdWithTagName(itemId = givenItemIds[0], givenTagNames[1]),
+        )
+
+        every { itemTagRepository.findItemTagNameItemIdIsIn(givenItemIds) } returns givenItemIdWithTagNames
+
+        When("아이템 아이디 리스트로 해당 아이디에 속한 태그 이름을 조회하면") {
+            val itemIdToTagNames = itemTagService.createItemIdToTagNames(itemIds = givenItemIds)
+
+            Then("아이템 아이디: key, 해당 아이템에 매핑된 태그 이름들이 value인 맵 형태로 해당 정보를 반환한다") {
+                itemIdToTagNames.size shouldBe 1
+                itemIdToTagNames[givenItemIds.first()] shouldBe givenTagNames
             }
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/tag/ItemTagServiceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 
 class ItemTagServiceTest : BehaviorSpec({
     val tagRepository = mockk<TagRepository>()
@@ -54,7 +55,7 @@ class ItemTagServiceTest : BehaviorSpec({
         }
     }
 
-    Given("특정 아이템에 등록된 태그들이 존재하는 경우") {
+    Given("아이템에 등록된 태그들이 존재하는 경우") {
         val givenTagNames = listOf("tag1", "tag2")
         val givenItemIds = listOf(generateRandomPositiveLongValue())
         val givenItemIdWithTagNames: List<ItemIdWithTagName> = listOf(
@@ -70,6 +71,18 @@ class ItemTagServiceTest : BehaviorSpec({
             Then("아이템 아이디: key, 해당 아이템에 매핑된 태그 이름들이 value인 맵 형태로 해당 정보를 반환한다") {
                 itemIdToTagNames.size shouldBe 1
                 itemIdToTagNames[givenItemIds.first()] shouldBe givenTagNames
+            }
+        }
+
+        When("빈 아이템 아이디 리스트로 해당 아이디에 속한 태그 이름을 조회하면") {
+            val givenEmptyIds = emptyList<Long>()
+            val result = itemTagService.createItemIdToTagNames(givenEmptyIds)
+
+            Then("실제로 태그를 조회하지 않고 빈 map을 반환한다") {
+                verify(exactly = 0) {
+                    itemTagRepository.findItemTagNameItemIdIsIn(any())
+                }
+                result shouldBe emptyMap()
             }
         }
     }


### PR DESCRIPTION
### 변경 내용 요약
아이템 검색 API 추가

### 작업한 내용
아이템을 조회할 때, 3가지 케이스를 통해 조회할 수 있습니다.
- 1. 별도 조건 없이 유저가 등록한 모든 아이템들을 대상으로 검색 
- 2. 특정 공간에 속한 아이템들을 대상으로 검색 
- 3. 특정 보관함에 속한 아이템을 대상으로 검색

**제공하는 검색(필터) 조건은 아래와 같습니다**
- 정렬
  - 선택 가능 옵션: 최근 등록순, 과거 등록순, 아이템 이름 오름차순, 아이템 이름 내림차순
- 카테고리
  - 식품, 생활, 패션등 여러 개 선택 가능
- 태그 검색 조건
  - 여러 태그 이름을 전달받아, 해당 태그가 모두 등록된 아이템을 필터링 할 수 있습니다.
- 아이템 이름 검색
  - 전달받은 단어가 이름에 포함되는 아이템들을 필터링할 수 있습니다.

여러 필터 조건이 설정된 경우, 모든 조건에 해당하는 아이템만 페이징해서 조회합니다.
각 아이템을 조회한 후, 아이템마다 최대 4개의 태그까지 아이템 응답 결과에 포함해서 반환합니다.

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-219)

### 기타 사항
- 아이템 검색 api request
```
curl --location --request POST 'http://localhost:8080/items/search?page=0' \
--header 'accept: */*' \
--header 'Authorization: Bearer token' \
--header 'Content-Type: application/json' \
--data-raw '{
    "sortOrderOption": "RecentCreated",
    "tagNames":["태그3"],
    "itemTypes":["FASHION","FOOD"],
    "itemName": "1",
    "searchTarget": {
        "location": "CONTAINER",
        "id": 1
    }
}'
```

- 아이템 검색 api response
```json
{
    "totalCount": 1,
    "totalPages": 1,
    "currentPageNumber": 0,
    "hasNext": false,
    "data": [
        {
            "tags": [
                "태그",
                "태그3"
            ],
            "id": 2,
            "name": "1",
            "quantity": 1,
            "itemType": "FASHION",
            "useByDate": "2023.01.27",
            "representativeImageUrl": "url1",
            "pinX": 29.0,
            "pinY": 20.0,
            "spaceName": "공간이름1",
            "containerName": "서재"
        }
    ]
}
```
