### PR TITLE
[A2Y-254] 공간 및 보관함 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
@@ -1,20 +1,24 @@
 package com.yapp.itemfinder.api
 
+import com.yapp.itemfinder.api.validation.UrlValidator
 import com.yapp.itemfinder.domain.container.dto.ContainerResponse
 import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
+import com.yapp.itemfinder.domain.container.dto.UpdateContainerRequest
 import com.yapp.itemfinder.domain.container.service.ContainerService
 import com.yapp.itemfinder.domain.member.MemberEntity
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
 @RestController
 class ContainerController(
-    private val containerService: ContainerService
+    private val containerService: ContainerService,
+    private val urlValidator: UrlValidator
 ) {
     @Operation(summary = "특정 공간에 등록된 모든 보관함 조회")
     @GetMapping("/containers/by-space-id/{spaceId}")
@@ -26,5 +30,18 @@ class ContainerController(
     @PostMapping("/containers")
     fun createContainer(@LoginMember member: MemberEntity, @RequestBody @Valid createContainerReq: CreateContainerRequest): ContainerResponse {
         return containerService.createContainer(member.id, createContainerReq)
+    }
+
+    @Operation(summary = "기존 보관함 수정")
+    @PutMapping("/containers/{containerId}")
+    fun updateContainer(
+        @LoginMember member: MemberEntity,
+        @PathVariable containerId: Long,
+        @RequestBody @Valid updateContainerRequest: UpdateContainerRequest
+    ): ContainerResponse {
+        updateContainerRequest.url?.let {
+            urlValidator.validate(it)
+        }
+        return containerService.updateContainer(member.id, containerId, updateContainerRequest)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ContainerController.kt
@@ -32,7 +32,7 @@ class ContainerController(
         return containerService.createContainer(member.id, createContainerReq)
     }
 
-    @Operation(summary = "기존 보관함 수정")
+    @Operation(summary = "기존에 등록했던 보관함 정보 수정")
     @PutMapping("/containers/{containerId}")
     fun updateContainer(
         @LoginMember member: MemberEntity,

--- a/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
@@ -6,9 +6,12 @@ import com.yapp.itemfinder.domain.space.service.SpaceService
 import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
+import com.yapp.itemfinder.domain.space.dto.UpdateSpaceRequest
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
@@ -34,5 +37,15 @@ class SpaceController(
     @GetMapping("/spaces/containers")
     fun getSpaceWithTopContainers(@LoginMember member: MemberEntity): List<SpaceWithTopContainerResponse> {
         return spaceService.getSpaceWithTopContainers(member.id)
+    }
+
+    @Operation(summary = "멤버가 등록한 공간의 정보를 수정")
+    @PutMapping("/spaces/{spaceId}")
+    fun updateSpace(
+        @LoginMember member: MemberEntity,
+        @PathVariable spaceId: Long,
+        @RequestBody updateSpaceReq: UpdateSpaceRequest
+    ): SpaceResponse {
+        return spaceService.updateSpace(member.id, spaceId, updateSpaceReq.name)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
@@ -44,8 +44,8 @@ class SpaceController(
     fun updateSpace(
         @LoginMember member: MemberEntity,
         @PathVariable spaceId: Long,
-        @RequestBody updateSpaceReq: UpdateSpaceRequest
+        @RequestBody updateSpaceRequest: UpdateSpaceRequest
     ): SpaceResponse {
-        return spaceService.updateSpace(member.id, spaceId, updateSpaceReq.name)
+        return spaceService.updateSpace(member.id, spaceId, updateSpaceRequest.name)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/api/validation/UrlValidator.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/validation/UrlValidator.kt
@@ -1,5 +1,6 @@
 package com.yapp.itemfinder.api.validation
 
+import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.common.Const
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
@@ -11,8 +12,15 @@ interface UrlValidator {
         val URL_PATTERN = Pattern.compile(Const.URL_REGEX)
     }
     fun isValid(url: String): Boolean
+
     fun isValid(urls: List<String>): Boolean {
         return urls.all { isValid(it) }
+    }
+
+    fun validate(url: String) {
+        require(isValid(url)) {
+            throw BadRequestException(message = "올바르지 않은 이미지로 요청하셨습니다.")
+        }
     }
 }
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerEntity.kt
@@ -1,5 +1,6 @@
 package com.yapp.itemfinder.domain.container
 
+import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.domain.BaseEntity
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import javax.persistence.AttributeConverter
@@ -46,6 +47,15 @@ class ContainerEntity(
 
     fun getCreatorId(): Long {
         return space.getCreatorId()
+    }
+
+    fun update(space: SpaceEntity, name: String, iconType: String, imageUrl: String?): ContainerEntity {
+        this.space = space
+        this.name = name
+        this.iconType = IconType.values().firstOrNull { it.name == iconType }
+            ?: throw BadRequestException(message = "올바르지 않은 아이콘으로 요청하셨습니다.")
+        this.imageUrl = imageUrl
+        return this
     }
 
     companion object {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/UpdateContainerRequest.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/dto/UpdateContainerRequest.kt
@@ -1,0 +1,22 @@
+package com.yapp.itemfinder.domain.container.dto
+
+import com.yapp.itemfinder.api.validation.EnumType
+import com.yapp.itemfinder.domain.container.ContainerEntity.Companion.CONTAINER_NAME_LENGTH_LIMIT
+import com.yapp.itemfinder.domain.container.IconType
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+class UpdateContainerRequest(
+    val spaceId: Long,
+
+    @field:NotBlank
+    @field:Size(min = 1, max = CONTAINER_NAME_LENGTH_LIMIT, message = "1자 이상 ${CONTAINER_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")
+    val name: String,
+
+    @EnumType(enumClass = IconType::class, message = "올바르지 않은 아이콘입니다")
+    @Schema(implementation = IconType::class)
+    val icon: String,
+
+    val url: String? = null,
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -60,17 +60,17 @@ class ContainerService(
 
     @Transactional
     fun updateContainer(memberId: Long, containerId: Long, updateContainerRequest: UpdateContainerRequest): ContainerResponse {
-        val existContainer = permissionValidator.validateContainerByMemberId(memberId, containerId)
+        val currentContainer = permissionValidator.validateContainerByMemberId(memberId, containerId)
         val (name, icon, url) = Triple(updateContainerRequest.name, updateContainerRequest.icon, updateContainerRequest.url)
         validateContainerNameExistInSpace(spaceId = updateContainerRequest.spaceId, name)
 
-        val space = if (existContainer.space.id != updateContainerRequest.spaceId) {
+        val space = if (currentContainer.space.id != updateContainerRequest.spaceId) {
             permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = updateContainerRequest.spaceId)
         } else {
-            existContainer.space
+            currentContainer.space
         }
 
-        return existContainer.update(
+        return currentContainer.update(
             space = space,
             name = name,
             iconType = icon,

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -62,6 +62,7 @@ class ContainerService(
     fun updateContainer(memberId: Long, containerId: Long, updateContainerRequest: UpdateContainerRequest): ContainerResponse {
         val existContainer = permissionValidator.validateContainerByMemberId(memberId, containerId)
         val (name, icon, url) = Triple(updateContainerRequest.name, updateContainerRequest.icon, updateContainerRequest.url)
+        validateContainerExist(spaceId = updateContainerRequest.spaceId, name)
 
         val space = if (existContainer.space.id != updateContainerRequest.spaceId) {
             permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = updateContainerRequest.spaceId)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -43,7 +43,7 @@ class ContainerService(
     @Transactional
     fun createContainer(memberId: Long, containerRequest: CreateContainerRequest): ContainerResponse {
         val space = spaceRepository.findByIdAndMemberIdOrThrowException(id = containerRequest.spaceId, memberId = memberId).also {
-            validateContainerExist(spaceId = it.id, containerName = containerRequest.name)
+            validateContainerNameExistInSpace(spaceId = it.id, containerName = containerRequest.name)
         }
 
         val container = ContainerEntity(
@@ -62,7 +62,7 @@ class ContainerService(
     fun updateContainer(memberId: Long, containerId: Long, updateContainerRequest: UpdateContainerRequest): ContainerResponse {
         val existContainer = permissionValidator.validateContainerByMemberId(memberId, containerId)
         val (name, icon, url) = Triple(updateContainerRequest.name, updateContainerRequest.icon, updateContainerRequest.url)
-        validateContainerExist(spaceId = updateContainerRequest.spaceId, name)
+        validateContainerNameExistInSpace(spaceId = updateContainerRequest.spaceId, name)
 
         val space = if (existContainer.space.id != updateContainerRequest.spaceId) {
             permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = updateContainerRequest.spaceId)
@@ -80,7 +80,7 @@ class ContainerService(
         }
     }
 
-    private fun validateContainerExist(spaceId: Long, containerName: String) {
+    private fun validateContainerNameExistInSpace(spaceId: Long, containerName: String) {
         containerRepository.findBySpaceIdAndName(spaceId = spaceId, name = containerName)?.let {
             throw ConflictException(message = "이미 해당 이름으로 공간에 등록된 보관함 존재합니다.")
         }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceEntity.kt
@@ -40,6 +40,12 @@ class SpaceEntity(
         return member.id
     }
 
+    fun updateSpace(name: String): SpaceEntity {
+        validateName(name)
+        this.name = name
+        return this
+    }
+
     private fun validateName(name: String) {
         require(name.isNotBlank() && name.length <= SPACE_NAME_LENGTH_LIMIT) {
             throw BadRequestException(message = "1자 이상 ${SPACE_NAME_LENGTH_LIMIT}자 이내로 이름을 등록해 주세요.")

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/UpdateSpaceRequest.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/dto/UpdateSpaceRequest.kt
@@ -1,0 +1,5 @@
+package com.yapp.itemfinder.domain.space.dto
+
+data class UpdateSpaceRequest(
+    val name: String
+)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -10,6 +10,7 @@ import com.yapp.itemfinder.domain.space.SpaceEntity
 import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
 import com.yapp.itemfinder.domain.space.dto.SpacesResponse
+import com.yapp.itemfinder.support.PermissionValidator
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class SpaceService(
     private val spaceRepository: SpaceRepository,
-    private val containerService: ContainerService
+    private val containerService: ContainerService,
+    private val permissionValidator: PermissionValidator,
 ) {
     @Transactional
     fun createSpace(spaceRequest: CreateSpaceRequest, member: MemberEntity): SpaceResponse {
@@ -49,6 +51,15 @@ class SpaceService(
                     .take(containerIconViewLimit)
                     .map { ContainerResponse(it) }
             )
+        }
+    }
+
+    @Transactional
+    fun updateSpace(memberId: Long, spaceId: Long, spaceName: String): SpaceResponse {
+        validateSpaceExist(memberId, spaceName)
+        val space = permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = spaceId)
+        return space.updateSpace(spaceName).run {
+            SpaceResponse(this)
         }
     }
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -24,7 +24,7 @@ class SpaceService(
     @Transactional
     fun createSpace(spaceRequest: CreateSpaceRequest, member: MemberEntity): SpaceResponse {
         val spaceName = spaceRequest.name
-        validateSpaceExist(member.id, spaceName)
+        validateSpaceNameExist(member.id, spaceName)
 
         val newSpace = spaceRepository.save(SpaceEntity(member = member, name = spaceName))
         return SpaceResponse(newSpace).also {
@@ -56,14 +56,14 @@ class SpaceService(
 
     @Transactional
     fun updateSpace(memberId: Long, spaceId: Long, spaceName: String): SpaceResponse {
-        validateSpaceExist(memberId, spaceName)
+        validateSpaceNameExist(memberId, spaceName)
         val space = permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = spaceId)
         return space.updateSpace(spaceName).run {
             SpaceResponse(this)
         }
     }
 
-    private fun validateSpaceExist(memberId: Long, spaceName: String) {
+    private fun validateSpaceNameExist(memberId: Long, spaceName: String) {
         spaceRepository.findByMemberIdAndName(memberId = memberId, name = spaceName)?.let {
             throw ConflictException(message = "이미 해당 이름으로 등록된 공간이 존재합니다.")
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerEntityTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerEntityTest.kt
@@ -1,0 +1,38 @@
+package com.yapp.itemfinder.domain.container
+
+import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.TestUtil.generateRandomString
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class ContainerEntityTest : BehaviorSpec({
+    Given("보관함을 수정할 때") {
+        val givenCurrentSpace = FakeEntity.createFakeSpaceEntity()
+        val givenContainer = FakeEntity.createFakeContainerEntity(
+            space = givenCurrentSpace,
+            name = generateRandomString(4),
+            imageUrl = generateRandomString(4),
+            iconType = IconType.IC_CONTAINER_1
+        )
+
+        val givenNewSpace = FakeEntity.createFakeSpaceEntity()
+        val (givenName, givenImageUrl) = generateRandomString(5) to generateRandomString(5)
+        val givenIconType = IconType.IC_CONTAINER_5
+
+        When("보관함이 위치한 공간, 이름, 아이콘, 이미지 URL이 주어진다면") {
+            val response = givenContainer.update(
+                space = givenNewSpace,
+                name = givenName,
+                imageUrl = givenImageUrl,
+                iconType = givenIconType.name
+            )
+
+            Then("해당 값들로 보관함 정보를 수정할 수 있다") {
+                response.space shouldBe givenNewSpace
+                response.name shouldBe givenName
+                response.imageUrl shouldBe givenImageUrl
+                response.iconType shouldBe givenIconType
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -58,7 +58,7 @@ class ContainerServiceTest : BehaviorSpec({
             val (givenName, givenIcon, givenUrl) = Triple(generateRandomString(4), IconType.IC_CONTAINER_7, generateRandomString(10))
             val (currentSpaceId, givenMemberId) = givenContainer.space.id to givenSpace.member.id
 
-            When("보관함의 위치는 수정하지 않고 보관함 자체에 대한 정보만 수정한다면") {
+            When("보관함의 위치는 수정하지 않고 보관함 자체에 대한 정보만 수정하고") {
                 val givenUpdateRequest = UpdateContainerRequest(spaceId = currentSpaceId, name = givenName, icon = givenIcon.name, url = givenUrl)
 
                 And("수정하려는 보관함에 대한 권한이 있고, 해당 공간에 동일한 보관한 명으로 존재하는 보관함이 존재하지 않는다면") {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceEntityTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/SpaceEntityTest.kt
@@ -48,4 +48,39 @@ class SpaceEntityTest : BehaviorSpec({
             }
         }
     }
+
+    Given("공간을 수정할 때") {
+        val givenMember = FakeEntity.createFakeMemberEntity()
+        val givenAlreadyExistSpace = SpaceEntity(
+            member = givenMember,
+            name = "spaceName"
+        )
+
+        When("제한된 글자를 초과하거나 1자 미만 및 공백으로 구성된 공간 이름이 주어지면") {
+            val nameOverLengthLimit: String = TestUtil.generateRandomString(SPACE_NAME_LENGTH_LIMIT + 1)
+            val givenInvalidNames = listOf(nameOverLengthLimit, "", "  ")
+
+            Then("해당 이름으로 공간을 수정할 수 없다") {
+                givenInvalidNames.forAll { givenName ->
+                    shouldThrow<BadRequestException> {
+                        givenAlreadyExistSpace.updateSpace(givenName)
+                    }
+                }
+            }
+        }
+
+        When("1자 이상 9자 이하의 적절한 공간 이름이 주어지면") {
+            val givenValidNames = listOf(TestUtil.generateRandomString(SPACE_NAME_LENGTH_LIMIT), "공간1", "공간2")
+
+            Then("정상적으로 공간을 수정할 수 있다") {
+                givenValidNames.forAll { givenName ->
+                    shouldNotThrow<Exception> {
+                        val response = givenAlreadyExistSpace.updateSpace(givenName)
+                        response.member shouldBe givenMember
+                        response.name shouldBe givenName
+                    }
+                }
+            }
+        }
+    }
 })


### PR DESCRIPTION
### 변경 내용 요약
공간 및 보관함 수정 API 추가

### 작업한 내용
- 공간 수정 API 추가
  - 공간의 이름 변경할 수 있습니다. 
    - 이미 유저가 동일한 이름으로 공간을 등록했는지 검증합니다
- 보관함 수정 API 추가
  - 보관함이 속한 공간 또한 변경할 수 있습니다.
  - 보관함의 정보(이미지, 이름, 아이콘 등)를 변경할 수 있습니다.
    - 이미 유저가 동일한 이름으로 해당 공간에 보관함을 등록했는지 검증합니다


### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-254)

### 기타 사항
- 공간 수정 API
  - request
    ```curl
      curl --location --request PUT 'http://localhost:8080/spaces/1' \
      --header 'Authorization: Bearer token' \
      --header 'Content-Type: application/json' \
      --data-raw '{
         "name": "newName"
      }'
     ```

  - response
    ```json
      {
          "name": "newName",
          "id": 1
      }
    ```
- 보관함 수정 API
  - request
    ```curl
      curl --location --request PUT 'http://localhost:8080/containers/1' \
      --header 'Authorization: Bearer token' \
      --header 'Content-Type: application/json' \
      --data-raw '{
         "spaceId": "1",
         "name":"newName",
         "icon":"IC_CONTAINER_3",
         "url":"https://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg"
      }'
     ```

  - response
    ```json
      {
          "id": 1,
          "icon": "IC_CONTAINER_3",
          "spaceId": 1,
          "name": "newName",
          "imageUrl": "https://imaging.nikon.com/lineup/dslr/df/img/sample/img_01.jpg"
      }
    ```
