### PR TITLE
[A2Y-189] 공간 삭제 api 추가 & 조회 조건 수정

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/SpaceController.kt
@@ -8,6 +8,7 @@ import com.yapp.itemfinder.domain.space.dto.SpaceResponse
 import com.yapp.itemfinder.domain.space.dto.SpaceWithTopContainerResponse
 import com.yapp.itemfinder.domain.space.dto.UpdateSpaceRequest
 import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -47,5 +48,14 @@ class SpaceController(
         @RequestBody updateSpaceRequest: UpdateSpaceRequest
     ): SpaceResponse {
         return spaceService.updateSpace(member.id, spaceId, updateSpaceRequest.name)
+    }
+
+    @Operation(summary = "멤버가 등록한 공간 삭제")
+    @DeleteMapping("/spaces/{spaceId}")
+    fun deleteSpace(
+        @LoginMember member: MemberEntity,
+        @PathVariable spaceId: Long
+    ) {
+        return spaceService.deleteSpace(member.id, spaceId)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -2,6 +2,7 @@ package com.yapp.itemfinder.domain.container
 
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
@@ -22,4 +23,8 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     fun findByMemberId(memberId: Long): List<ContainerEntity>
 
     fun countBySpace(space: SpaceEntity): Long
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from ContainerEntity c where c in :containers")
+    fun deleteByContainerIsIn(containers: List<ContainerEntity>)
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/ContainerRepository.kt
@@ -2,7 +2,6 @@ package com.yapp.itemfinder.domain.container
 
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
@@ -23,8 +22,4 @@ interface ContainerRepository : JpaRepository<ContainerEntity, Long> {
     fun findByMemberId(memberId: Long): List<ContainerEntity>
 
     fun countBySpace(space: SpaceEntity): Long
-
-    @Modifying(clearAutomatically = true)
-    @Query("delete from ContainerEntity c where c in :containers")
-    fun deleteByContainerIsIn(containers: List<ContainerEntity>)
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -104,6 +104,6 @@ class ContainerService(
     @Transactional
     fun deleteContainers(containers: List<ContainerEntity>) {
         itemRepository.deleteAllByContainerIsIn(containers)
-        containerRepository.deleteByContainerIsIn(containers)
+        containerRepository.deleteAll(containers)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -89,13 +89,21 @@ class ContainerService(
         }
     }
 
-    @Transactional
     fun deleteContainer(memberId: Long, containerId: Long) {
         val container = permissionValidator.validateContainerByMemberId(memberId, containerId)
         if (containerRepository.countBySpace(container.space) == 1L) {
             throw BadRequestException(message = "공간 내 보관함은 최소 1개 이상 존재해야 합니다")
         }
-        itemRepository.deleteAllByContainer(container)
-        containerRepository.delete(container)
+        deleteContainers(listOf(container))
+    }
+
+    fun deleteContainersInSpace(space: SpaceEntity) {
+        deleteContainers(containerRepository.findBySpace(space))
+    }
+
+    @Transactional
+    fun deleteContainers(containers: List<ContainerEntity>) {
+        itemRepository.deleteAllByContainerIsIn(containers)
+        containerRepository.deleteByContainerIsIn(containers)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -7,7 +7,7 @@ import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.container.dto.ContainerResponse
 import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.container.dto.UpdateContainerRequest
-import com.yapp.itemfinder.domain.item.ItemRepository
+import com.yapp.itemfinder.domain.item.ItemService
 import com.yapp.itemfinder.domain.space.SpaceEntity
 import com.yapp.itemfinder.domain.space.SpaceRepository
 import com.yapp.itemfinder.domain.space.findByIdAndMemberIdOrThrowException
@@ -21,7 +21,7 @@ class ContainerService(
     private val containerRepository: ContainerRepository,
     private val spaceRepository: SpaceRepository,
     private val permissionValidator: PermissionValidator,
-    private val itemRepository: ItemRepository
+    private val itemService: ItemService
 ) {
     fun getSpaceIdToContainers(spaceIds: List<Long>): Map<Long, List<ContainerVo>> {
         return containerRepository.findBySpaceIdIsIn(spaceIds)
@@ -103,7 +103,7 @@ class ContainerService(
 
     @Transactional
     fun deleteContainers(containers: List<ContainerEntity>) {
-        itemRepository.deleteAllByContainerIsIn(containers)
-        containerRepository.deleteAll(containers)
+        itemService.deleteItemsInContainers(containers)
+        containerRepository.deleteAllInBatch(containers)
     }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -23,7 +23,7 @@ interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySuppor
     )
     fun findByIdWithContainerAndSpace(id: Long): ItemEntity?
 
-    fun deleteAllByContainerIsIn(containers: List<ContainerEntity>)
+    fun findByContainerIsIn(containers: List<ContainerEntity>): List<ItemEntity>
 }
 
 fun ItemRepository.findByIdWithContainerAndSpaceOrThrowException(id: Long): ItemEntity {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -12,6 +12,7 @@ import com.yapp.itemfinder.support.PaginationHelper
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySupport {
@@ -23,7 +24,9 @@ interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySuppor
     )
     fun findByIdWithContainerAndSpace(id: Long): ItemEntity?
 
-    fun deleteAllByContainer(container: ContainerEntity)
+    @Modifying(clearAutomatically = true)
+    @Query("delete from ItemEntity i where i.container in :containers")
+    fun deleteAllByContainerIsIn(containers: List<ContainerEntity>)
 }
 
 fun ItemRepository.findByIdWithContainerAndSpaceOrThrowException(id: Long): ItemEntity {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -12,7 +12,6 @@ import com.yapp.itemfinder.support.PaginationHelper
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySupport {
@@ -24,8 +23,6 @@ interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySuppor
     )
     fun findByIdWithContainerAndSpace(id: Long): ItemEntity?
 
-    @Modifying(clearAutomatically = true)
-    @Query("delete from ItemEntity i where i.container in :containers")
     fun deleteAllByContainerIsIn(containers: List<ContainerEntity>)
 }
 

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -3,6 +3,7 @@ package com.yapp.itemfinder.domain.item
 import com.yapp.itemfinder.common.PageResponse
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.api.exception.ForbiddenException
+import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
@@ -94,7 +95,17 @@ class ItemService(
     @Transactional
     fun deleteItem(itemId: Long, memberId: Long) {
         val item = findMemberItemOrThrowException(itemId, memberId)
-        itemRepository.delete(item)
+        deleteItems(listOf(item))
+    }
+
+    @Transactional
+    fun deleteItems(items: List<ItemEntity>) {
+        itemTagService.deleteItemTagsByItems(items)
+        itemRepository.deleteAllInBatch(items)
+    }
+
+    fun deleteItemsInContainers(containers: List<ContainerEntity>) {
+        deleteItems(itemRepository.findByContainerIsIn(containers))
     }
 
     @Transactional

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/SpaceRepository.kt
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query
 
 interface SpaceRepository : JpaRepository<SpaceEntity, Long>, SpaceRepositorySupport {
     fun findByMemberIdAndName(memberId: Long, name: String): SpaceEntity?
-    fun findByMemberId(memberId: Long): List<SpaceEntity>
+    fun findByMemberIdOrderByCreatedAtAsc(memberId: Long): List<SpaceEntity>
     @Query("select s from SpaceEntity s where s.id = :id and s.member.id = :memberId")
     fun findByIdAndMemberId(id: Long, memberId: Long): SpaceEntity?
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -68,4 +68,11 @@ class SpaceService(
             throw ConflictException(message = "이미 해당 이름으로 등록된 공간이 존재합니다.")
         }
     }
+
+    @Transactional
+    fun deleteSpace(memberId: Long, spaceId: Long) {
+        val space = permissionValidator.validateSpaceByMemberId(memberId, spaceId)
+        containerService.deleteContainersInSpace(space)
+        spaceRepository.delete(space)
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/space/service/SpaceService.kt
@@ -33,7 +33,7 @@ class SpaceService(
     }
 
     fun getSpaces(memberId: Long): SpacesResponse {
-        val spaces = spaceRepository.findByMemberId(memberId)
+        val spaces = spaceRepository.findByMemberIdOrderByCreatedAtAsc(memberId)
         return SpacesResponse.from(spaces)
     }
     fun getSpaceWithTopContainers(memberId: Long): List<SpaceWithTopContainerResponse> {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagRepository.kt
@@ -1,8 +1,11 @@
 package com.yapp.itemfinder.domain.tag
 
+import com.yapp.itemfinder.domain.item.ItemEntity
 import com.yapp.itemfinder.domain.tag.dto.TagWithItemTypeDto
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface ItemTagRepository : JpaRepository<ItemTagEntity, Long> {
     @Query(
@@ -19,6 +22,11 @@ interface ItemTagRepository : JpaRepository<ItemTagEntity, Long> {
             "from ItemTagEntity itemTag inner join TagEntity tag on itemTag.tag = tag where itemTag.item.id in :itemIds"
     )
     fun findItemIdAndTagNameByItemIdIsIn(itemIds: List<Long>): List<ItemIdWithTagName>
+
+    @Modifying
+    @Transactional
+    @Query("delete from ItemTagEntity i where i.item in :items")
+    fun deleteAllByItemIsIn(items: List<ItemEntity>)
 }
 
 data class ItemIdWithTagName(

--- a/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/tag/ItemTagService.kt
@@ -34,4 +34,9 @@ class ItemTagService(
             .groupBy { it.itemId }
             .mapValues { (_, itemTagNames) -> itemTagNames.map { it.tagName } }
     }
+
+    @Transactional
+    fun deleteItemTagsByItems(items: List<ItemEntity>) {
+        itemTagRepository.deleteAllByItemIsIn(items)
+    }
 }

--- a/src/main/kotlin/com/yapp/itemfinder/support/PermissionValidator.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/support/PermissionValidator.kt
@@ -32,7 +32,7 @@ class PermissionValidator(
 
     private fun validateCreatorIdAndRequestId(creatorMemberId: Long, requestMemberId: Long) {
         if (creatorMemberId != requestMemberId) {
-            throw ForbiddenException(message = "해당 권한이 없습니다.")
+            throw ForbiddenException(message = "해당 권한이 없습니다")
         }
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/ControllerIntegrationTest.kt
@@ -2,6 +2,12 @@ package com.yapp.itemfinder
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import com.yapp.itemfinder.FakeEntity.createFakeContainerEntity
+import com.yapp.itemfinder.FakeEntity.createFakeItemEntity
+import com.yapp.itemfinder.FakeEntity.createFakeItemTagEntity
+import com.yapp.itemfinder.FakeEntity.createFakeMemberEntity
+import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
+import com.yapp.itemfinder.FakeEntity.createFakeTagEntity
 import com.yapp.itemfinder.api.LoginMemberResolver
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.ItemEntity
@@ -9,6 +15,9 @@ import com.yapp.itemfinder.domain.item.ItemRepository
 import com.yapp.itemfinder.domain.member.MemberEntity
 import com.yapp.itemfinder.domain.member.MemberRepository
 import com.yapp.itemfinder.domain.space.SpaceRepository
+import com.yapp.itemfinder.domain.tag.ItemTagEntity
+import com.yapp.itemfinder.domain.tag.ItemTagRepository
+import com.yapp.itemfinder.domain.tag.TagRepository
 import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,6 +53,12 @@ abstract class ControllerIntegrationTest {
     @Autowired
     lateinit var itemRepository: ItemRepository
 
+    @Autowired
+    lateinit var itemTagRepository: ItemTagRepository
+
+    @Autowired
+    lateinit var tagRepository: TagRepository
+
     @MockkBean
     lateinit var loginMemberArgumentResolver: LoginMemberResolver
 
@@ -60,7 +75,7 @@ abstract class ControllerIntegrationTest {
         testMember = createTestMember()
     }
     protected fun createTestMember(): MemberEntity {
-        val givenMember = memberRepository.save(FakeEntity.createFakeMemberEntity())
+        val givenMember = memberRepository.save(createFakeMemberEntity())
 
         every { loginMemberArgumentResolver.supportsParameter(any()) } returns true
         every { loginMemberArgumentResolver.resolveArgument(any(), any(), any(), any()) } returns givenMember
@@ -69,8 +84,13 @@ abstract class ControllerIntegrationTest {
     }
 
     fun createItem(member: MemberEntity): ItemEntity {
-        val givenSpace = spaceRepository.save(FakeEntity.createFakeSpaceEntity(member = member))
-        val givenContainer = containerRepository.save(FakeEntity.createFakeContainerEntity(space = givenSpace))
-        return itemRepository.save(FakeEntity.createFakeItemEntity(container = givenContainer))
+        val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = member))
+        val givenContainer = containerRepository.save(createFakeContainerEntity(space = givenSpace))
+        return itemRepository.save(createFakeItemEntity(container = givenContainer))
+    }
+
+    fun createItemTag(item: ItemEntity): ItemTagEntity {
+        val givenTag = tagRepository.save(createFakeTagEntity(member = testMember))
+        return itemTagRepository.save(createFakeItemTagEntity(item = item, tag = givenTag))
     }
 }

--- a/src/test/kotlin/com/yapp/itemfinder/api/ContainerControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ContainerControllerTest.kt
@@ -7,9 +7,14 @@ import com.yapp.itemfinder.FakeEntity.createFakeSpaceEntity
 import com.yapp.itemfinder.domain.item.ItemEntity
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.delete
+import javax.persistence.EntityManager
 
 class ContainerControllerTest : ControllerIntegrationTest() {
+    @Autowired
+    lateinit var entityManager: EntityManager
+
     @Test
     fun `보관함 2개가 등록된 공간 내부의 보관함을 1개 삭제하면 내부 물건도 함께 삭제된다`() {
         // given
@@ -28,6 +33,7 @@ class ContainerControllerTest : ControllerIntegrationTest() {
             }
 
         // then
+        entityManager.clear()
         containerRepository.findById(givenContainer.id).isEmpty shouldBe true
         givenItems.map { itemRepository.findById(it.id).isEmpty shouldBe true }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/api/ItemControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/ItemControllerTest.kt
@@ -8,13 +8,10 @@ import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
 import com.yapp.itemfinder.domain.item.dto.UpdateItemRequest
 import com.yapp.itemfinder.domain.tag.ItemTagEntity
-import com.yapp.itemfinder.domain.tag.ItemTagRepository
 import com.yapp.itemfinder.domain.tag.TagEntity
-import com.yapp.itemfinder.domain.tag.TagRepository
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
@@ -24,12 +21,6 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 class ItemControllerTest : ControllerIntegrationTest() {
-    @Autowired
-    lateinit var tagRepository: TagRepository
-
-    @Autowired
-    lateinit var itemTagRepository: ItemTagRepository
-
     @Test
     fun `회원이 등록한 보관함 안에 물건을 등록할 수 있다`() {
         // given

--- a/src/test/kotlin/com/yapp/itemfinder/api/SpaceControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/SpaceControllerTest.kt
@@ -83,8 +83,10 @@ class SpaceControllerTest : ControllerIntegrationTest() {
         repeat(3) {
             val container = containerRepository.save(createFakeContainerEntity(space = givenSpace))
             givenContainers.add(container)
-            itemRepository.save(createFakeItemEntity(container = container))
-            itemRepository.save(createFakeItemEntity(container = container))
+            val firstItem = itemRepository.save(createFakeItemEntity(container = container))
+            val secondItem = itemRepository.save(createFakeItemEntity(container = container))
+            createItemTag(firstItem)
+            createItemTag(secondItem)
         }
 
         // when

--- a/src/test/kotlin/com/yapp/itemfinder/api/TagControllerTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/api/TagControllerTest.kt
@@ -5,20 +5,16 @@ import com.yapp.itemfinder.ControllerIntegrationTest
 import com.yapp.itemfinder.FakeEntity
 import com.yapp.itemfinder.TestUtil.generateRandomString
 import com.yapp.itemfinder.domain.item.ItemType
-import com.yapp.itemfinder.domain.tag.TagRepository
 import com.yapp.itemfinder.domain.tag.dto.CreateTagsRequest
 import com.yapp.itemfinder.domain.tag.dto.TagWithItemTypeResponse
 import com.yapp.itemfinder.domain.tag.dto.TagsResponse
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 
 class TagControllerTest : ControllerIntegrationTest() {
-    @Autowired
-    lateinit var tagRepository: TagRepository
     @Test
     fun `회원은 10글자 이내의 태그를 등록할 수 있다`() {
         // given

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -96,4 +96,26 @@ class ContainerRepositoryTest(
             }
         }
     }
+
+    Given("공간에 보관함 3개가 저장되어 있을 때") {
+        val givenMember = memberRepository.save(createFakeMemberEntity())
+        val givenSpace = spaceRepository.save(createFakeSpaceEntity(member = givenMember))
+        val givenContainers = mutableListOf<ContainerEntity>()
+        repeat(3) {
+            containerRepository.save(createFakeContainerEntity(space = givenSpace))
+                .let {
+                    givenContainers.add(it)
+                }
+        }
+
+        When("보관함 2개를 삭제하면") {
+            containerRepository.deleteByContainerIsIn(givenContainers.subList(0, 1))
+
+            Then("보관함 2개가 모두 삭제된다") {
+                givenContainers.subList(0, 1).map {
+                    containerRepository.findById(it.id).isEmpty shouldBe true
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/ContainerRepositoryTest.kt
@@ -109,7 +109,7 @@ class ContainerRepositoryTest(
         }
 
         When("보관함 2개를 삭제하면") {
-            containerRepository.deleteByContainerIsIn(givenContainers.subList(0, 1))
+            containerRepository.deleteAll(givenContainers.subList(0, 1))
 
             Then("보관함 2개가 모두 삭제된다") {
                 givenContainers.subList(0, 1).map {

--- a/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/container/service/ContainerServiceTest.kt
@@ -13,7 +13,7 @@ import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.container.IconType
 import com.yapp.itemfinder.domain.container.dto.CreateContainerRequest
 import com.yapp.itemfinder.domain.container.dto.UpdateContainerRequest
-import com.yapp.itemfinder.domain.item.ItemRepository
+import com.yapp.itemfinder.domain.item.ItemService
 import com.yapp.itemfinder.domain.space.SpaceRepository
 import com.yapp.itemfinder.domain.space.findByIdAndMemberIdOrThrowException
 import com.yapp.itemfinder.support.PermissionValidator
@@ -30,8 +30,8 @@ class ContainerServiceTest : BehaviorSpec({
     val containerRepository = mockk<ContainerRepository>(relaxed = true)
     val spaceRepository = mockk<SpaceRepository>(relaxed = true)
     val permissionValidator = mockk<PermissionValidator>(relaxed = true)
-    val itemRepository = mockk<ItemRepository>()
-    val containerService = ContainerService(containerRepository, spaceRepository, permissionValidator, itemRepository)
+    val itemService = mockk<ItemService>()
+    val containerService = ContainerService(containerRepository, spaceRepository, permissionValidator, itemService)
 
     Given("특정 공간에 보관함이 등록되어 있을 때") {
         val givenSpaceId = generateRandomPositiveLongValue()

--- a/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/space/service/SpaceServiceTest.kt
@@ -82,7 +82,7 @@ class SpaceServiceTest : BehaviorSpec({
         val givenMemberId = generateRandomPositiveLongValue()
 
         When("등록한 공간이 없으면") {
-            every { spaceRepository.findByMemberId(givenMemberId) } returns emptyList()
+            every { spaceRepository.findByMemberIdOrderByCreatedAtAsc(givenMemberId) } returns emptyList()
 
             Then("빈 공간 정보 리스트를 담은 값을 반환한다") {
                 val result = spaceService.getSpaces(givenMemberId)
@@ -93,7 +93,7 @@ class SpaceServiceTest : BehaviorSpec({
         When("등록한 공간이 있으면") {
             val (givenSpaceId, givenSpaceName, givenMember) = Triple(generateRandomPositiveLongValue(), "공간명", createFakeMemberEntity())
             val givenSpace = createFakeSpaceEntity(id = givenSpaceId, name = givenSpaceName, member = givenMember)
-            every { spaceRepository.findByMemberId(givenMemberId) } returns listOf(givenSpace)
+            every { spaceRepository.findByMemberIdOrderByCreatedAtAsc(givenMemberId) } returns listOf(givenSpace)
 
             Then("해당 공간 정보(id, 이름) 리스트를 담은 값을 반환한다") {
                 val result = spaceService.getSpaces(givenMemberId)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,3 +36,8 @@ cloud:
             mock.port: 8001
         stack:
             auto: false
+
+logging:
+    level:
+        org.hibernate.SQL: debug
+        org.hibernate.type.descriptor.sql: trace


### PR DESCRIPTION
### 변경 내용 요약
- 공간 조회 조건 수정
- 공간 삭제 api 추가 

### 작업한 내용
- 공간 조회 조건 수정
  - 오래된 순으로 조회하도록 조회 조건 수정
- 공간 삭제 api 추가
  - 공간 내 모든 보관함 및 물건도 함께 삭제

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-189?atlOrigin=eyJpIjoiODY0MDZlYTNiMTcyNDhlYWI1YjAzZjJlZjNhOGFmNDQiLCJwIjoiaiJ9)

### 기타 사항

공간 삭제 api
- request
  ```curl -X 'DELETE' \
  'http://localhost:8080/spaces/6' \
  -H 'accept: */*' \
  -H 'Authorization: Bearer 토큰값'
  ```
