### PR TITLE
[A2Y-259] 소비기한 설정한 아이템 관련 페이징 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/ItemController.kt
@@ -6,7 +6,9 @@ import com.yapp.itemfinder.api.validation.UrlValidator
 import com.yapp.itemfinder.domain.item.ItemService
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
+import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
+import com.yapp.itemfinder.domain.item.dto.ItemWithDueDateResponse
 import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
 import com.yapp.itemfinder.domain.item.dto.UpdateItemRequest
 import com.yapp.itemfinder.domain.member.MemberEntity
@@ -67,6 +69,22 @@ class ItemController(
     ): PageResponse<ItemOverviewResponse> {
         val pageRequest = PageRequest.of(page, size, searchOption.getSort())
         return itemService.search(searchOption, pageRequest, member.id)
+    }
+
+    @Operation(summary = "소비기한 설정한 아이템 조회")
+    @GetMapping("/by-due-date")
+    fun searchByDueDate(
+        @LoginMember member: MemberEntity,
+        @RequestParam(required = false, defaultValue = "0") @Min(0) page: Int,
+        @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(10) size: Int,
+        @RequestParam target: ItemDueDateTarget
+    ): PageResponse<ItemWithDueDateResponse> {
+        val pageRequest = PageRequest.of(page, size)
+        return itemService.searchByDueDate(
+            pageRequest = pageRequest,
+            memberId = member.id,
+            dueDateTarget = target
+        )
     }
 
     @Operation(summary = "물건 삭제")

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/CustomException.kt
@@ -38,4 +38,10 @@ class ForbiddenException(
     errorCode: ErrorCode? = null
 ) : BaseException(httpStatus, message, errorCode)
 
+class InternalServerException(
+    httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+    message: String? = null,
+    errorCode: ErrorCode? = null
+) : BaseException(httpStatus, message, errorCode)
+
 const val INVALID_TOKEN_MESSAGE = "유효하지 않은 토큰입니다."

--- a/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/api/exception/GlobalExceptionHandler.kt
@@ -68,7 +68,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ErrorResponse(ex.message, ex.errorCode?.value))
     }
 
-    @ExceptionHandler(Exception::class)
+    @ExceptionHandler(Exception::class, InternalServerException::class)
     fun handleException(ex: Exception): ResponseEntity<ErrorResponse> {
         logger.error("message=${ex.message}")
         return ResponseEntity.status(INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemRepository.kt
@@ -3,9 +3,15 @@ package com.yapp.itemfinder.domain.item
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.yapp.itemfinder.api.exception.NotFoundException
+import com.yapp.itemfinder.common.Const.KST_ZONE_ID
 import com.yapp.itemfinder.domain.container.ContainerEntity
+import com.yapp.itemfinder.domain.container.QContainerEntity.containerEntity
 import com.yapp.itemfinder.domain.item.QItemEntity.itemEntity
+import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget
+import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget.PASSED
+import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget.REMAINED
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
+import com.yapp.itemfinder.domain.space.QSpaceEntity.spaceEntity
 import com.yapp.itemfinder.domain.tag.QItemTagEntity.itemTagEntity
 import com.yapp.itemfinder.domain.tag.QTagEntity.tagEntity
 import com.yapp.itemfinder.support.PaginationHelper
@@ -13,6 +19,9 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositorySupport {
     @Query(
@@ -32,6 +41,7 @@ fun ItemRepository.findByIdWithContainerAndSpaceOrThrowException(id: Long): Item
 
 interface ItemRepositorySupport {
     fun search(searchOption: ItemSearchOption, pageable: Pageable, targetContainerIds: List<Long>): Page<ItemEntity>
+    fun searchByDueDate(pageable: Pageable, memberId: Long, dueDateTarget: ItemDueDateTarget): Page<ItemEntity>
 }
 
 class ItemRepositorySupportImpl(
@@ -53,6 +63,29 @@ class ItemRepositorySupportImpl(
             .having(tagEntity.count().goe(searchOption.tagNames.size))
 
         return paginationHelper.getPage(pageable, query, ItemEntity::class.java)
+    }
+
+    override fun searchByDueDate(pageable: Pageable, memberId: Long, dueDateTarget: ItemDueDateTarget): Page<ItemEntity> {
+        val query = queryFactory.select(itemEntity)
+            .from(itemEntity)
+            .innerJoin(containerEntity).on(itemEntity.container.id.eq(containerEntity.id))
+            .innerJoin(spaceEntity).on(containerEntity.space.id.eq(spaceEntity.id))
+            .where(
+                spaceEntity.member.id.eq(memberId),
+                dueDateConditionOnTarget(dueDateTarget)
+            )
+            .orderBy(itemEntity.dueDate.asc())
+        return paginationHelper.getPage(pageable, query, ItemEntity::class.java)
+    }
+
+    private fun dueDateConditionOnTarget(dueDateTarget: ItemDueDateTarget): BooleanExpression {
+        val today = LocalDate.now(KST_ZONE_ID)
+        val targetDateTime = LocalDateTime.of(today, LocalTime.MIN)
+
+        return when (dueDateTarget) {
+            REMAINED -> itemEntity.dueDate.goe(targetDateTime)
+            PASSED -> itemEntity.dueDate.lt(targetDateTime)
+        }
     }
 
     private fun containerIdIsIn(targetContainerIds: List<Long>): BooleanExpression {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -5,7 +5,9 @@ import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.api.exception.ForbiddenException
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
+import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget
 import com.yapp.itemfinder.domain.item.dto.ItemDetailResponse
+import com.yapp.itemfinder.domain.item.dto.ItemWithDueDateResponse
 import com.yapp.itemfinder.domain.item.dto.ItemOverviewResponse
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SearchTarget
@@ -55,6 +57,16 @@ class ItemService(
     fun findItem(itemId: Long, memberId: Long): ItemDetailResponse {
         val item = findMemberItemOrThrowException(itemId, memberId)
         return ItemDetailResponse(item)
+    }
+
+    fun searchByDueDate(pageRequest: PageRequest, memberId: Long, dueDateTarget: ItemDueDateTarget): PageResponse<ItemWithDueDateResponse> {
+        val item = itemRepository.searchByDueDate(pageRequest, memberId, dueDateTarget)
+
+        return PageResponse(
+            page = item.map {
+                ItemWithDueDateResponse.from(it)
+            }
+        )
     }
 
     fun search(searchOption: ItemSearchOption, pageRequest: PageRequest, memberId: Long): PageResponse<ItemOverviewResponse> {

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemDueDateTarget.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemDueDateTarget.kt
@@ -1,0 +1,6 @@
+package com.yapp.itemfinder.domain.item.dto
+
+enum class ItemDueDateTarget {
+    PASSED,
+    REMAINED
+}

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponse.kt
@@ -1,0 +1,34 @@
+package com.yapp.itemfinder.domain.item.dto
+
+import com.yapp.itemfinder.api.exception.InternalServerException
+import com.yapp.itemfinder.common.Const.KST_ZONE_ID
+import com.yapp.itemfinder.common.DateTimeFormatter.YYYYMMDD
+import com.yapp.itemfinder.domain.item.ItemEntity
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+data class ItemWithDueDateResponse(
+    val id: Long,
+    val name: String,
+    val itemType: String,
+    val useByDate: String,
+    val remainDate: Long
+) {
+
+    companion object {
+        fun from(item: ItemEntity): ItemWithDueDateResponse {
+            val dueDate: LocalDateTime = item.dueDate ?: throw InternalServerException(message = "해당 아이템은 소비기한이 존재하지 않습니다. id: ${item.id}")
+            val today = LocalDate.now(KST_ZONE_ID)
+            val remainDueDate = ChronoUnit.DAYS.between(today, dueDate.toLocalDate())
+
+            return ItemWithDueDateResponse(
+                id = item.id,
+                name = item.name,
+                itemType = item.type.name,
+                useByDate = dueDate.format(YYYYMMDD),
+                remainDate = remainDueDate
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/FakeEntity.kt
@@ -13,6 +13,7 @@ import com.yapp.itemfinder.domain.space.SpaceEntity
 import com.yapp.itemfinder.domain.space.SpaceEntity.Companion.SPACE_NAME_LENGTH_LIMIT
 import com.yapp.itemfinder.domain.tag.ItemTagEntity
 import com.yapp.itemfinder.domain.tag.TagEntity
+import java.time.LocalDateTime
 import java.util.UUID
 
 object FakeEntity {
@@ -63,14 +64,16 @@ object FakeEntity {
         container: ContainerEntity = createFakeContainerEntity(space = createFakeSpaceEntity()),
         name: String = generateRandomString(10),
         type: ItemType = ItemType.LIFE,
-        quantity: Int = 1
+        quantity: Int = 1,
+        dueDate: LocalDateTime? = null,
     ): ItemEntity {
         return ItemEntity(
             id = id,
             container = container,
             name = name,
             type = type,
-            quantity = quantity
+            quantity = quantity,
+            dueDate = dueDate
         )
     }
 

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponseTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponseTest.kt
@@ -1,0 +1,72 @@
+package com.yapp.itemfinder.domain.item.dto
+
+import com.yapp.itemfinder.FakeEntity
+import com.yapp.itemfinder.api.exception.InternalServerException
+import com.yapp.itemfinder.common.Const.KST_ZONE_ID
+import com.yapp.itemfinder.common.DateTimeFormatter.YYYYMMDD
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class ItemWithDueDateResponseTest : BehaviorSpec({
+    Given("소비기한이 설정된 아이템이 주어졌을 때") {
+        val givenLocalDateTime = LocalDateTime.now(KST_ZONE_ID)
+
+        When("오늘 날짜를 기준으로 비교했을 때 아이템의 소비기한이 지났으면") {
+            val (passedDays, passedYear) = 4L to 1L
+            val daysPassedItem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.minusDays(passedDays))
+            val yearPassedITem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.minusYears(passedYear))
+
+            Then("지난 일자를 계산해 -N일 형태로 담아 반환한다") {
+                val daysPassedResult = ItemWithDueDateResponse.from(daysPassedItem)
+                val yearPassedResult = ItemWithDueDateResponse.from(yearPassedITem)
+
+                assertSoftly {
+                    daysPassedResult.remainDate shouldBe -1 * passedDays
+                    yearPassedResult.remainDate shouldBe -365
+
+                    daysPassedResult.id shouldBe daysPassedItem.id
+                    daysPassedResult.name shouldBe daysPassedItem.name
+                    daysPassedResult.itemType shouldBe daysPassedItem.type.name
+                    daysPassedResult.useByDate shouldBe daysPassedItem.dueDate?.format(YYYYMMDD)
+                }
+            }
+        }
+
+        When("오늘 날짜를 기준으로 비교했을 때 아이템의 소비기한이 남았으면") {
+            val remainDate = 4L
+            val (remainedDays, remainedYear) = 4L to 1L
+            val daysRemainedItem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.plusDays(remainedDays))
+            val yearRemainedItem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.plusYears(remainedYear))
+
+            Then("남은 일자를 계산해 +N일 형태로 담아 반환한다") {
+                val daysRemainedResult = ItemWithDueDateResponse.from(daysRemainedItem)
+                val yearRemainedResult = ItemWithDueDateResponse.from(yearRemainedItem)
+
+                assertSoftly {
+                    daysRemainedResult.remainDate shouldBe remainDate
+                    yearRemainedResult.remainDate shouldBe 365
+
+                    daysRemainedResult.id shouldBe daysRemainedItem.id
+                    daysRemainedResult.name shouldBe daysRemainedItem.name
+                    daysRemainedResult.itemType shouldBe daysRemainedItem.type.name
+                    daysRemainedResult.useByDate shouldBe daysRemainedItem.dueDate?.format(YYYYMMDD)
+                }
+            }
+        }
+    }
+
+    Given("소비기한이 설정되지 않은 아이템이 주어졌을 때") {
+        val givenItem = FakeEntity.createFakeItemEntity(dueDate = null)
+
+        When("해당 응답으로 변환을 시도하면") {
+            Then("예외가 발생한다") {
+                shouldThrow<InternalServerException> {
+                    ItemWithDueDateResponse.from(givenItem)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
### 변경 내용 요약
소비기한 설정한 아이템 관련 페이징 조회 API 추가

### 작업한 내용
소비기한 설정한 아이템 관련 페이징 조회 API 추가
- 소비기한이 지난 아이템 조회
  - 지난 일자를 계산해서 반환합니다.
- 소비기한이 남아있는 아이템 조회
  - 남아있는 일자를 계산해서 반환합니다.


### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-259)

### 기타 사항
- 소비기한이 지난 아이템 조회
  - request
  ```shell
    curl --location --request GET 'http://localhost:8080/items/by-due-date?page=0&size=10&target=PASSED' \
    --header 'Authorization: Bearer token'
  ```
  - response
  ```json
    {
        "totalCount": 11,
        "totalPages": 2,
        "currentPageNumber": 0,
        "hasNext": true,
        "data": [
            {
                "id": 134,
                "name": "item",
                "itemType": "LIFE",
                "useByDate": "2023.02.03",
                "remainDate": -9
            },
            {
                "id": 133,
                "name": "item",
                "itemType": "LIFE",
                "useByDate": "2023.02.04",
                "remainDate": -8
            },
        ...
        ]
    }
  ```
- 소비기한이 남은 아이템 조회
  - request
  ```curl
    curl --location --request GET 'http://localhost:8080/items/by-due-date?page=0&size=10&target=REMAINED' \
    --header 'Authorization: Bearer token'
  ```
  - response
  ```json
      {
          "totalCount": 2,
          "totalPages": 1,
          "currentPageNumber": 0,
          "hasNext": false,
          "data": [
              {
                  "id": 125,
                  "name": "item",
                  "itemType": "LIFE",
                  "useByDate": "2023.02.12",
                  "remainDate": 0
              },
              {
                  "id": 135,
                  "name": "item",
                  "itemType": "LIFE",
                  "useByDate": "2023.02.19",
                  "remainDate": 7
              }
          ]
      }
  ```