### PR TITLE
[A2Y-272] 보관함 수정 시 보관함 명을 변경했을 경우에만 이름 검증을 진행하도록 수정

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/container/service/ContainerService.kt
@@ -65,7 +65,10 @@ class ContainerService(
     fun updateContainer(memberId: Long, containerId: Long, updateContainerRequest: UpdateContainerRequest): ContainerResponse {
         val currentContainer = permissionValidator.validateContainerByMemberId(memberId, containerId)
         val (name, icon, url) = Triple(updateContainerRequest.name, updateContainerRequest.icon, updateContainerRequest.url)
-        validateContainerNameExistInSpace(spaceId = updateContainerRequest.spaceId, name)
+
+        if (currentContainer.name != name) {
+            validateContainerNameExistInSpace(spaceId = updateContainerRequest.spaceId, name)
+        }
 
         val space = if (currentContainer.space.id != updateContainerRequest.spaceId) {
             permissionValidator.validateSpaceByMemberId(memberId = memberId, spaceId = updateContainerRequest.spaceId)


### PR DESCRIPTION
### 변경 내용 요약
보관함 수정 시 보관함 명을 변경했을 경우에만 이름 검증(공간 내 동일 보관함 명 존재)을 진행하도록 수정

### 
### 작업한 내용
**AS IS**
보관함 정보를 변경할 경우 항상 공간 내 동일한 보관함 명이 존재하는지 검증 진행하므로 유저가 보관함 명을 수정하지 않을 경우 검증에 실패하여 보관함 수정을 진행하지 못합니다.

**TO BE**
보관함 명을 다른 이름으로 변경한 경우에만 공간 내 동일한 보관함 명이 존재하는지 검증하고, 보관함 명을 수정하지 않을 경우 검증을 진행하지 않도록 수정했습니다.

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-272)

