### PR TITLE
[A2Y-223] 운영환경 AWS 인프라 세팅 및 github action 추가

### DIFF
--- a/.github/workflows/cicd-prod.yaml
+++ b/.github/workflows/cicd-prod.yaml
@@ -1,0 +1,74 @@
+name: cicd-prod
+
+on:
+    workflow_dispatch:
+
+env:
+    ACTIVE_PROFILE: "prod"
+    DOCKERHUB_ID: ${{ secrets.PROD_DOCKERHUB_ID }}
+    DOCKERHUB_PASSWORD: ${{ secrets.PROD_DOCKERHUB_PASSWORD }}
+    DOCKERHUB_REPO: ${{ secrets.PROD_DOCKERHUB_REPO }}
+
+jobs:
+    build-and-ci:
+        runs-on: ubuntu-latest
+        outputs:
+            image_tag: ${{ steps.image_tag.outputs.image_tag }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Set up JDK 17
+              uses: actions/setup-java@v3
+              with:
+                  java-version: '17'
+                  distribution: 'temurin'
+
+            - name: Cache Gradle packages
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                  restore-keys: |
+                      ${{ runner.os }}-gradle-
+
+            - name: Create yaml file
+              run: |
+                  touch ./src/main/resources/application-$ACTIVE_PROFILE.yml
+                  echo "${{ secrets.PROD_APPLICATION_YAML }}" >> ./src/main/resources/application-$ACTIVE_PROFILE.yml
+
+            - name: Add permission for gradlew
+              run: chmod +x ./gradlew
+
+            - name: gradle Build
+              run: ./gradlew build
+
+            - name: Make image tag value to tag version
+              run: echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+
+            - name: Build docker image and push image
+              run: |
+                  docker login -u $DOCKERHUB_ID -p $DOCKERHUB_PASSWORD
+                  docker build --build-arg SPRING_PROFILES_ACTIVE=$ACTIVE_PROFILE -t $DOCKERHUB_REPO:${{env.IMAGE_TAG}} .
+                  docker push $DOCKERHUB_REPO:${{env.IMAGE_TAG}}
+
+            - name: Pass Image tag value
+              id: image_tag
+              run: echo "image_tag=${{env.IMAGE_TAG}}" >> $GITHUB_OUTPUT
+
+    cd:
+        needs: build-and-ci
+        runs-on: [ yapp-prod-server ]
+        steps:
+            - name: Set image tag value from output value
+              run: echo "IMAGE_TAG=${{ needs.build-and-ci.outputs.image_tag }}" >> $GITHUB_ENV
+
+            - name: Run docker image
+              run: |
+                  docker pull $DOCKERHUB_REPO:${{env.IMAGE_TAG}}
+                  docker stop yapp 2> /dev/null || echo "yapp container doesn't exist"
+                  docker rm yapp 2> /dev/null || echo "yapp container doesn't exist"
+                  docker run --restart always -d -p 8080:8080 --add-host host.docker.internal:host-gateway --name yapp $DOCKERHUB_REPO:${{env.IMAGE_TAG}}

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/ItemRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.yapp.itemfinder.TestCaseUtil
 import com.yapp.itemfinder.TestUtil.generateRandomPositiveLongValue
 import com.yapp.itemfinder.TestUtil.generateRandomString
 import com.yapp.itemfinder.api.exception.NotFoundException
+import com.yapp.itemfinder.common.Const.KST_ZONE_ID
 import com.yapp.itemfinder.domain.item.dto.ItemDueDateTarget
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption
 import com.yapp.itemfinder.domain.item.dto.ItemSearchOption.SortOrderOption
@@ -226,7 +227,7 @@ class ItemRepositoryTest(
 
         val (givenMember, givenContainer) = testCaseUtil.`한 명의 회원과 해당 회원이 저장한 보관함 반환`()
         val (givenPassedDueDateCount, givenRemainedDueDateCount) = 3 to 2
-        val today = LocalDateTime.now()
+        val today = LocalDateTime.now(KST_ZONE_ID)
 
         repeat(givenPassedDueDateCount) {
             itemRepository.save(createFakeItemEntity(container = givenContainer, type = ItemType.LIFE, dueDate = today.minusDays(it.toLong() + 1)))


### PR DESCRIPTION
### 변경 내용 요약
운영환경 AWS 인프라 세팅 및 github action 추가

### 작업한 내용
- 운영환경 AWS 인프라 세팅 
- github action 추가
  - 운영 환경의 경우 main 브랜치에 머지 시 바로 깃헙 액션을 트리거 하지 않고, 메인 머지 후 해당 커밋 관련하여 신규 tag 생성하여 이를 기반으로 직접 Action 탭을 통해 깃헙 액션을 트리거 하는 방향으로 진행합니다. 
  - 현재 테스트로 [0.0.1-test](https://github.com/YAPP-Github/21st-Android-Team-2-BE/releases/tag/0.0.1-test) 태그를 생성해서 이를 기반으로 추가한 github action(cicd-prod)를 실행하였고 배포가 정상적으로 잘 되는 것을 확인했습니다.

### 관련 링크
- [지라 티켓](https://and2y21.atlassian.net/browse/A2Y-223)
