### PR TITLE
Fix: 소비기한 측정하는 방식 변경

### DIFF
--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/ItemService.kt
@@ -3,6 +3,7 @@ package com.yapp.itemfinder.domain.item
 import com.yapp.itemfinder.common.PageResponse
 import com.yapp.itemfinder.api.exception.BadRequestException
 import com.yapp.itemfinder.api.exception.ForbiddenException
+import com.yapp.itemfinder.common.Const.KST_ZONE_ID
 import com.yapp.itemfinder.domain.container.ContainerEntity
 import com.yapp.itemfinder.domain.container.ContainerRepository
 import com.yapp.itemfinder.domain.item.dto.CreateItemRequest
@@ -21,6 +22,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
@@ -65,7 +67,7 @@ class ItemService(
 
         return PageResponse(
             page = item.map {
-                ItemWithDueDateResponse.from(it)
+                ItemWithDueDateResponse.from(it, LocalDate.now(KST_ZONE_ID))
             }
         )
     }

--- a/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponse.kt
+++ b/src/main/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponse.kt
@@ -1,7 +1,6 @@
 package com.yapp.itemfinder.domain.item.dto
 
 import com.yapp.itemfinder.api.exception.InternalServerException
-import com.yapp.itemfinder.common.Const.KST_ZONE_ID
 import com.yapp.itemfinder.common.DateTimeFormatter.YYYYMMDD
 import com.yapp.itemfinder.domain.item.ItemEntity
 import java.time.LocalDate
@@ -17,17 +16,16 @@ data class ItemWithDueDateResponse(
 ) {
 
     companion object {
-        fun from(item: ItemEntity): ItemWithDueDateResponse {
+        fun from(item: ItemEntity, targetDate: LocalDate): ItemWithDueDateResponse {
             val dueDate: LocalDateTime = item.dueDate ?: throw InternalServerException(message = "해당 아이템은 소비기한이 존재하지 않습니다. id: ${item.id}")
-            val today = LocalDate.now(KST_ZONE_ID)
-            val remainDueDate = ChronoUnit.DAYS.between(today, dueDate.toLocalDate())
+            val remainDueDateFromTargetDate = ChronoUnit.DAYS.between(targetDate, dueDate.toLocalDate())
 
             return ItemWithDueDateResponse(
                 id = item.id,
                 name = item.name,
                 itemType = item.type.name,
                 useByDate = dueDate.format(YYYYMMDD),
-                remainDate = remainDueDate
+                remainDate = remainDueDateFromTargetDate
             )
         }
     }

--- a/src/test/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponseTest.kt
+++ b/src/test/kotlin/com/yapp/itemfinder/domain/item/dto/ItemWithDueDateResponseTest.kt
@@ -2,17 +2,17 @@ package com.yapp.itemfinder.domain.item.dto
 
 import com.yapp.itemfinder.FakeEntity
 import com.yapp.itemfinder.api.exception.InternalServerException
-import com.yapp.itemfinder.common.Const.KST_ZONE_ID
 import com.yapp.itemfinder.common.DateTimeFormatter.YYYYMMDD
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class ItemWithDueDateResponseTest : BehaviorSpec({
     Given("소비기한이 설정된 아이템이 주어졌을 때") {
-        val givenLocalDateTime = LocalDateTime.now(KST_ZONE_ID)
+        val givenLocalDateTime = LocalDateTime.of(2022, 1, 1, 0, 0, 0)
 
         When("오늘 날짜를 기준으로 비교했을 때 아이템의 소비기한이 지났으면") {
             val (passedDays, passedYear) = 4L to 1L
@@ -20,8 +20,8 @@ class ItemWithDueDateResponseTest : BehaviorSpec({
             val yearPassedITem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.minusYears(passedYear))
 
             Then("지난 일자를 계산해 -N일 형태로 담아 반환한다") {
-                val daysPassedResult = ItemWithDueDateResponse.from(daysPassedItem)
-                val yearPassedResult = ItemWithDueDateResponse.from(yearPassedITem)
+                val daysPassedResult = ItemWithDueDateResponse.from(daysPassedItem, givenLocalDateTime.toLocalDate())
+                val yearPassedResult = ItemWithDueDateResponse.from(yearPassedITem, givenLocalDateTime.toLocalDate())
 
                 assertSoftly {
                     daysPassedResult.remainDate shouldBe -1 * passedDays
@@ -42,8 +42,8 @@ class ItemWithDueDateResponseTest : BehaviorSpec({
             val yearRemainedItem = FakeEntity.createFakeItemEntity(dueDate = givenLocalDateTime.plusYears(remainedYear))
 
             Then("남은 일자를 계산해 +N일 형태로 담아 반환한다") {
-                val daysRemainedResult = ItemWithDueDateResponse.from(daysRemainedItem)
-                val yearRemainedResult = ItemWithDueDateResponse.from(yearRemainedItem)
+                val daysRemainedResult = ItemWithDueDateResponse.from(daysRemainedItem, givenLocalDateTime.toLocalDate())
+                val yearRemainedResult = ItemWithDueDateResponse.from(yearRemainedItem, givenLocalDateTime.toLocalDate())
 
                 assertSoftly {
                     daysRemainedResult.remainDate shouldBe remainDate
@@ -64,7 +64,10 @@ class ItemWithDueDateResponseTest : BehaviorSpec({
         When("해당 응답으로 변환을 시도하면") {
             Then("예외가 발생한다") {
                 shouldThrow<InternalServerException> {
-                    ItemWithDueDateResponse.from(givenItem)
+                    ItemWithDueDateResponse.from(
+                        item = givenItem,
+                        targetDate = LocalDate.of(2022, 1, 1)
+                    )
                 }
             }
         }


### PR DESCRIPTION
### 변경 내용 요약
아이템 소비기한 측정하는 방식 변경

### 작업한 내용
윤년으로 인해 관련 테스트가 실패하여, 날짜를 파라미터로 받는 방향으로 수정했습니다.

